### PR TITLE
Separate validation and require a PAT secret

### DIFF
--- a/.github/workflows/gitflow-release.yaml
+++ b/.github/workflows/gitflow-release.yaml
@@ -23,10 +23,8 @@ env:
   IS_CUSTOM_VERSION: ${{ github.event.inputs.version-change == 'custom' }}
 
 jobs:
-  release:
+  validate:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Check actor permission
         uses: skjnldsv/check-actor-permission@v2.1
@@ -45,8 +43,15 @@ jobs:
         name: Custom Version must be "#.#.#"
         run: echo "Custom Version must be #.#.#" exit 1;
 
+  release:
+    runs-on: ubuntu-latest
+    needs: validate
+    permissions:
+      contents: write
+    steps:
       - uses: actions/checkout@v3
         with:
+          token: ${{secrets.PAT}}
           fetch-depth: "0"
 
       - name: get new version


### PR DESCRIPTION
GitHub hasn't created a suitable permission schema to let GitHub actions make changes to protected branches. PAT is the main solution other than managing changes with PRs. See the [community discussion](https://github.com/orgs/community/discussions/25305) for more details.

I created a fine-grained token in my repo fork to test pushing to a protected branch:
![image](https://github.com/aklivity/zilla-docs/assets/3012311/843fddf5-4c5a-495e-a74e-3df518de1c1d)


fixes https://github.com/aklivity/aklivity-docs/issues/20