### PR TITLE
add nvm to install instruction

### DIFF
--- a/src/tutorials/todo-app/build.md
+++ b/src/tutorials/todo-app/build.md
@@ -647,6 +647,7 @@ Next, you will build the `Todo` app that's implemented using [VueJs](https://vue
 ```bash:no-line-numbers
 git clone https://github.com/aklivity/todo-app && \
 cd todo-app && \
+nvm install && nvm use \
 npm install && \
 npm run build && \
 cd ..


### PR DESCRIPTION
Update institutions so users will use the correct version of node, per changes made in [todo-app PR](https://github.com/aklivity/todo-app/pull/5#)