### PR TITLE
Fix root redirects

### DIFF
--- a/src/.vuepress/public/cloudflare/_redirects
+++ b/src/.vuepress/public/cloudflare/_redirects
@@ -1,3 +1,3 @@
-/* /zilla/latest 302
-/zilla/* /zilla/latest 302
+/ /zilla/latest 302
+/zilla/ /zilla/latest 302
 /zilla/latest/library /zilla/latest 302


### PR DESCRIPTION
Wildcards aren't needed as the only two cases we want to redirect are root `/` and `/zilla`. I manually tested it by uploading the file to Cloudflare and confirmed it works. 