### PR TITLE
Remove generate command

### DIFF
--- a/src/reference/config/zilla-cli.md
+++ b/src/reference/config/zilla-cli.md
@@ -16,10 +16,6 @@ The Zilla Runtime command line interface uses the [Zilla Runtime Configuration](
   - [-i --install `<plugin-directory>`](#i-install-plugin-directory)
   - [-v --verbose](#v-verbose)
   - [-w --write `<output>`](#w-write-output)
-- [zilla generate](#zilla-generate)
-  - [-t --template `<template>`](#t-template-template)
-  - [-i --input `<input-file>`](#i-input-input-file)
-  - [-o --output `<output-file>`](#o-output-output-file)
 - [zilla help](#zilla-help)
 - [zilla metrics](#zilla-metrics)
   - [--namespace `<namespace>`](#namespace-namespace)
@@ -85,44 +81,6 @@ Example:
 
 ```bash:no-line-numbers
 ./zilla dump -v -w zilla.pcap
-```
-
-### zilla generate
-
-::: important Feature is in Incubator
-Read how to [enable incubator features](../../how-tos/deploy-operate.md#enable-incubator-features). Star and watch the [Zilla repo](https://github.com/aklivity/zilla/releases) for new releases!
-:::
-
-The `zilla generate` command generates a zilla configuration file from an OpenAPI or AsyncAPI service definition.
-
-The command currently has templates for the following common scenarios:
-
-- `openapi.http.proxy` - create an http proxy config based on an OpenAPI service definition
-- `asyncapi.http.proxy` - create an http proxy config based on an AsyncAPI service definition
-- `asyncapi.mqtt.proxy` - create an mqtt proxy config based on an AsyncAPI service definition
-
-You have to specify which template to use, the OpenAPI/AsyncAPI service definition as the input file and the output file name you want the generated zilla config to be saved.
-
-```bash:no-line-numbers
-zilla generate -t <template> -i <input-file> -o <output-file>
-```
-
-#### -t --template `<template>`
-
-The template to use for the config generation.
-
-#### -i --input `<input-file>`
-
-The OpenAPI/AsyncAPI service definition.
-
-#### -o --output `<output-file>`
-
-The file name you want the generated zilla config to be saved.
-
-Example:
-
-```bash:no-line-numbers
-./zilla generate -t asyncapi.http.proxy -i my-asyncapi-service.yaml -o zilla.yaml
 ```
 
 ### zilla help


### PR DESCRIPTION
This change removes the obsolete `generate` command.