### PR TITLE
Fix wrong configuration in the MQTT Kafka broker guide

### DIFF
--- a/src/cookbooks/mqtt.kafka.broker/zilla.yaml
+++ b/src/cookbooks/mqtt.kafka.broker/zilla.yaml
@@ -72,6 +72,7 @@ bindings:
               - topic: device/#
         with:
           messages: mqtt-devices
+        exit: north_kafka_cache_client
     #endregion device_mapping
 
   #region kafka_sync


### PR DESCRIPTION
There is an error in the [MQTT Kafka broker guide](https://docs.aklivity.io/zilla/latest/how-tos/mqtt/mqtt.kafka.broker.html) .

The route of the mqtt-kafka  binding does not declare an exit in the `zilla.yaml` file. Apparently the default exit is not applied for the route. Zilla still starts up correctly, but MQTT clients receive a connection error when trying to connect and no error is logged, making the configuration error difficult to debug.

fixes #279 