### PR TITLE
docs: update catalogs reference for schema changes

### DIFF
--- a/.check-schema/index.js
+++ b/.check-schema/index.js
@@ -199,7 +199,7 @@ const main = async () => {
             } else if (i.const) {
                 props.push([`${path}: ${i.const}`, req, "`const`", getExtraProps(i)]);
             } else if (i.enum?.length) {
-                i.enum.forEach((e) => props.push([`${path}: ${e}`, req, type, getExtraProps(i)]));
+                props.push([path, req, type, getExtraProps(i)]);
             } else if (i.oneOf) {
                 props.push([
                     path,

--- a/src/reference/config/catalogs/.partials/options-schema-registry.md
+++ b/src/reference/config/catalogs/.partials/options-schema-registry.md
@@ -6,7 +6,7 @@ The `schema-registry` specific options.
 
 #### options.url
 
-> `string`
+> `string` | Pattern: `^https?://`
 
 Schema Registry URL to access schemas via API calls.
 
@@ -36,23 +36,23 @@ tls:
     - client1
 ```
 
-##### options.tls.keys
+#### tls.keys
 
 > `array` of `string`
 
 A list of reference names for the Vault key.
 
-##### options.tls.trust
+#### tls.trust
 
 > `array` of `string`
 
 A list of reference names for the Vault certificate.
 
-##### options.tls.trustcacerts
+#### tls.trustcacerts
 
 > `boolean`
 
-Trust CA certificates. When the this property is not explicitly set it will be automatically set to `true` if [options.tls.trust](#options-tls-trust) is `null`.
+Trust CA certificates. When the this property is not explicitly set it will be automatically set to `true` if [tls.trust](#tls-trust) is `null`.
 
 #### options.credentials
 
@@ -66,13 +66,13 @@ credentials:
     authorization: Basic dXNlcjpzZWNyZXQ=
 ```
 
-##### options.credentials.headers
+#### credentials.headers
 
 > `object`
 
 Authentication headers to be included in requests to the Schema Registry.
 
-###### options.credentials.headers.authorization
+##### headers.authorization
 
 > `string`
 

--- a/src/reference/config/catalogs/aws-glue.md
+++ b/src/reference/config/catalogs/aws-glue.md
@@ -25,13 +25,19 @@ catalog:
 
 ## Configuration (\* required)
 
+### vault
+
+> `string`
+
+Vault name.
+
 ### options
 
 > `object`
 
 The `aws-glue` specific options.
 
-#### options.registry\*
+#### options.registry
 
 > `string`
 
@@ -39,12 +45,12 @@ The AWS Glue Registry name to access schemas.
 
 #### options.max-age
 
-> `integer` | Default: `300`
+> `number` | Default: `300`
 
 Configures the time to live in `seconds` for the schema information retrieved against the latest version. The default is 300 seconds or 5 minutes.
 
 #### options.compression
 
-> `enum` [ `none`, `zlib` ] | Default: `none`
+> `enum` [ `none`, `zlib` ]
 
 Configures the compression level for the message payloads that are serialized by the models configured in this catalog.


### PR DESCRIPTION
Resolves #352

## Changes

### `aws-glue` catalog
- Add `vault` optional string field
- `options.registry`: remove required marker
- `options.max-age`: change type `integer` → `number`
- `options.compression`: single `enum` heading replacing the previous per-value entries

### `confluent-schema-registry`, `karapace-schema-registry`, `schema-registry` catalogs (via shared partial)
- `options.url`: add `Pattern: ^https?://`
- Rename `options.tls.keys` → `tls.keys`, `options.tls.trust` → `tls.trust`, `options.tls.trustcacerts` → `tls.trustcacerts`
- Rename `options.credentials.headers` → `credentials.headers`, `options.credentials.headers.authorization` → `headers.authorization`

### Schema checker (`check-schema/index.js`)
- Fix bare `enum` properties (no `type` field) to generate a single entry instead of one entry per enum value