### PR TITLE
Add mcp-http binding reference documentation

### DIFF
--- a/src/.vuepress/sidebar/en.ts
+++ b/src/.vuepress/sidebar/en.ts
@@ -118,6 +118,13 @@ export const enSidebar = sidebar({
           children: "structure",
         },
         {
+          text: "MCP-HTTP",
+          icon: "fa-solid fa-robot",
+          prefix: "mcp-http",
+          collapsible: true,
+          children: "structure",
+        },
+        {
           text: "MQTT",
           icon: "fa-solid fa-wifi",
           prefix: "mqtt",

--- a/src/reference/config/bindings/mcp-http/.partials/options.md
+++ b/src/reference/config/bindings/mcp-http/.partials/options.md
@@ -109,7 +109,7 @@ Converter validating the `tools/call` `arguments` before the upstream `http` req
 
 Model name used to convert and validate the value, such as `json`.
 
-#### input.catalog\*
+#### input.catalog
 
 > `object` as map of named `array`
 

--- a/src/reference/config/bindings/mcp-http/.partials/options.md
+++ b/src/reference/config/bindings/mcp-http/.partials/options.md
@@ -1,0 +1,162 @@
+### options
+
+> `object`
+
+The `mcp_http` specific options.
+
+```yaml
+options:
+  authorization:
+    my_guard:
+      credentials:
+        headers:
+          authorization: Bearer {credentials}
+  tools:
+    create_pr:
+      description: Create a pull request to merge one branch into another.
+      summary: "Created pull request #${result.number}"
+      schemas:
+        input:
+          model: json
+          catalog:
+            my_catalog:
+              - subject: create_pr_params
+                version: latest
+        output:
+          model: json
+          catalog:
+            my_catalog:
+              - subject: create_pr_result
+                version: latest
+  resources:
+    order:
+      uri: "order://{orderId}"
+      description: Customer order by identifier
+      mimeType: application/json
+      schemas:
+        output:
+          model: json
+          catalog:
+            my_catalog:
+              - subject: order_result
+                version: latest
+```
+
+#### options.authorization
+
+> `object` as map of named `object`
+
+Guard credentials to inject into the upstream `http` request. The named key references a [guard](../../guards/README.md) defined elsewhere in the configuration. At most one guard may be referenced.
+
+#### authorization.credentials
+
+> `object`
+
+Credentials derived from the named guard.
+
+#### credentials.headers
+
+> `object` as map of named `string`
+
+HTTP request headers added to the upstream request, with values resolved from the guarded session.
+
+- `{credentials}` Replaced with the raw credentials presented to the named guard.
+- `{identity}` Replaced with the authorized identity resolved by the named guard.
+
+#### options.tools
+
+> `object` as map of named `object`
+
+MCP tools terminated by this binding and expanded into `http` requests. The named key is the tool name surfaced to MCP clients by `tools/list` and matched by `tools/call`.
+
+#### tools.description
+
+> `string`
+
+Tool description surfaced to MCP clients by `tools/list`.
+
+#### tools.summary
+
+> `string`
+
+Result summary template surfaced as the tool-call text result. Supports `${result.x}` interpolation, where `x` references a property of the upstream JSON response.
+
+#### tools.schemas\*
+
+> `object`
+
+JSON schema converters for the tool.
+
+#### schemas.input\*
+
+> `object`
+
+Converter validating the `tools/call` `arguments` before the upstream `http` request is dispatched. A converter binds a `model` to a registered `catalog` subject.
+
+#### input.model\*
+
+> `string`
+
+Model name used to convert and validate the value, such as `json`.
+
+#### input.catalog\*
+
+> `object` as map of named `array`
+
+Catalog subjects resolving the schema used for validation.
+
+#### catalog[].subject\*
+
+> `string`
+
+Subject name identifying the schema in the named catalog.
+
+#### catalog[].version
+
+> `string` | Default: `latest`
+
+Specific version of the registered schema.
+
+#### schemas.output
+
+> `object`
+
+Converter validating and projecting the upstream `http` response, surfaced as the tool-call `structuredContent`. Uses the same shape as [`schemas.input`](#schemas-input).
+
+#### options.resources
+
+> `object` as map of named `object`
+
+MCP resources terminated by this binding and expanded into `http` requests. The named key is the resource name surfaced to MCP clients by `resources/list` and matched by `resources/read`.
+
+#### resources.uri\*
+
+> `string`
+
+Resource URI template surfaced by `resources/list`, with optional embedded capture names, such as `order://{orderId}`. Captured values are referenced from a route as `${params.x}`.
+
+#### resources.description
+
+> `string`
+
+Resource description surfaced to MCP clients by `resources/list`.
+
+#### resources.mimeType
+
+> `string`
+
+MIME type of the resource contents surfaced to MCP clients.
+
+#### resources.schemas
+
+> `object`
+
+JSON schema converter for the resource.
+
+<!-- markdownlint-disable MD024 -->
+#### schemas.output
+
+> `object`
+
+Converter validating and projecting the upstream `http` response, surfaced as the resource `contents`. Uses the same shape as [`schemas.input`](#schemas-input).
+<!-- markdownlint-enable MD024 -->

--- a/src/reference/config/bindings/mcp-http/.partials/options.md
+++ b/src/reference/config/bindings/mcp-http/.partials/options.md
@@ -40,6 +40,16 @@ options:
             my_catalog:
               - subject: order_result
                 version: latest
+  prompts:
+    summarize:
+      description: Summarize a document about a topic
+      arguments:
+        - name: topic
+          description: The topic to summarize
+          required: true
+      messages:
+        - role: user
+          text: "Please summarize the document about ${args.topic}."
 ```
 
 #### options.authorization
@@ -160,3 +170,57 @@ JSON schema converter for the resource.
 
 Converter validating and projecting the upstream `http` response, surfaced as the resource `contents`. Uses the same shape as [`schemas.input`](#schemas-input).
 <!-- markdownlint-enable MD024 -->
+
+#### options.prompts
+
+> `object` as map of named `object`
+
+MCP prompts served locally by this binding. The named key is the prompt name surfaced to MCP clients by `prompts/list` and matched by `prompts/get`. A `prompts/get` request renders the messages locally with no upstream `http` request.
+
+#### prompts.description
+
+> `string`
+
+Prompt description surfaced to MCP clients by `prompts/list`.
+
+#### prompts.arguments
+
+> `array` of `object`
+
+Arguments accepted by the prompt, surfaced to MCP clients by `prompts/list` and supplied on `prompts/get`.
+
+#### arguments[].name\*
+
+> `string`
+
+Argument name, referenced from a message template as `${args.name}`.
+
+#### arguments[].description
+
+> `string`
+
+Argument description surfaced to MCP clients.
+
+#### arguments[].required
+
+> `boolean` | Default: `false`
+
+Whether the argument must be supplied on `prompts/get`.
+
+#### prompts.messages\*
+
+> `array` of `object`
+
+Message templates rendered and returned by `prompts/get`.
+
+#### messages[].role\*
+
+> `enum` [ `user`, `assistant` ]
+
+Role of the rendered message.
+
+#### messages[].text\*
+
+> `string`
+
+Message text template. Supports `${args.x}` interpolation, where `x` references a prompt argument supplied on `prompts/get`.

--- a/src/reference/config/bindings/mcp-http/.partials/proxy.yaml
+++ b/src/reference/config/bindings/mcp-http/.partials/proxy.yaml
@@ -1,0 +1,63 @@
+mcp_http_proxy:
+  type: mcp_http
+  kind: proxy
+  options:
+    authorization:
+      my_guard:
+        credentials:
+          headers:
+            authorization: Bearer {credentials}
+    tools:
+      create_pr:
+        description: Create a pull request to merge one branch into another.
+        summary: "Created pull request #${result.number}"
+        schemas:
+          input:
+            model: json
+            catalog:
+              my_catalog:
+                - subject: create_pr_params
+                  version: latest
+          output:
+            model: json
+            catalog:
+              my_catalog:
+                - subject: create_pr_result
+                  version: latest
+    resources:
+      order:
+        uri: "order://{orderId}"
+        description: Customer order by identifier
+        mimeType: application/json
+        schemas:
+          output:
+            model: json
+            catalog:
+              my_catalog:
+                - subject: order_result
+                  version: latest
+  routes:
+    - when:
+        - tool: create_pr
+      exit: http_client
+      with:
+        headers:
+          ":method": POST
+          ":scheme": https
+          ":authority": api.github.com
+          ":path": /repos/${args.owner}/${args.repo}/pulls
+        body:
+          model: json
+          catalog:
+            my_catalog:
+              - subject: create_pr_body
+                version: latest
+    - when:
+        - resource: order
+      exit: http_client
+      with:
+        headers:
+          ":method": GET
+          ":scheme": https
+          ":authority": api.orders.internal
+          ":path": /orders/${params.orderId}

--- a/src/reference/config/bindings/mcp-http/.partials/proxy.yaml
+++ b/src/reference/config/bindings/mcp-http/.partials/proxy.yaml
@@ -36,6 +36,16 @@ mcp_http_proxy:
               my_catalog:
                 - subject: order_result
                   version: latest
+    prompts:
+      summarize:
+        description: Summarize a document about a topic
+        arguments:
+          - name: topic
+            description: The topic to summarize
+            required: true
+        messages:
+          - role: user
+            text: "Please summarize the document about ${args.topic}."
   routes:
     - when:
         - tool: create_pr

--- a/src/reference/config/bindings/mcp-http/.partials/routes.md
+++ b/src/reference/config/bindings/mcp-http/.partials/routes.md
@@ -1,0 +1,141 @@
+### routes
+
+> `array` of `object`
+
+Conditional `mcp_http` specific routes, resolving the upstream `http` request for a matched `tools/call` or `resources/read`.
+
+```yaml
+routes:
+  - when:
+      - tool: create_pr
+    exit: http_client
+    with:
+      headers:
+        ":method": POST
+        ":scheme": https
+        ":authority": api.github.com
+        ":path": /repos/${args.owner}/${args.repo}/pulls
+      body:
+        model: json
+        catalog:
+          my_catalog:
+            - subject: create_pr_body
+              version: latest
+  - when:
+      - resource: order
+    exit: http_client
+    with:
+      headers:
+        ":method": GET
+        ":scheme": https
+        ":authority": api.orders.internal
+        ":path": /orders/${params.orderId}
+```
+
+#### routes[].guarded
+
+> `object` as map of named `array` of `string`
+
+Roles required by the named guard. When a guarded route matches, the MCP session must be authorized for the listed roles, otherwise the stream is rejected.
+
+```yaml
+routes:
+  - guarded:
+      my_guard:
+        - pr:write
+```
+
+#### routes[].when
+
+> `array` of `object`
+
+List of conditions (any match) to match this route.
+Read more: [When a route matches](/concepts/protocol/README.md#route-matches)
+
+```yaml
+routes:
+  - when:
+      - tool: create_pr
+      - resource: order
+```
+
+#### when[].tool
+
+> `string`
+
+Tool name to match, referencing an entry in [`options.tools`](#options-tools).
+
+#### when[].resource
+
+> `string`
+
+Resource name to match, referencing an entry in [`options.resources`](#options-resources).
+
+#### routes[].with\*
+
+> `object`
+
+Resolves the upstream `http` request for the matched route.
+
+```yaml
+with:
+  headers:
+    ":method": POST
+    ":scheme": https
+    ":authority": api.github.com
+    ":path": /repos/${args.owner}/${args.repo}/pulls
+  body:
+    model: json
+    catalog:
+      my_catalog:
+        - subject: create_pr_body
+          version: latest
+```
+
+#### with.headers\*
+
+> `object` as map of named `string`
+
+HTTP request headers for the upstream request, including the pseudo-headers `:method`, `:scheme`, `:authority`, and `:path`. Values support interpolation.
+
+- `${args.x}` Replaced with property `x` of the `tools/call` arguments.
+- `${params.x}` Replaced with capture `x` from the matched resource [`uri`](#resources-uri).
+
+#### with.query
+
+> `object`
+
+Converter projecting the `tools/call` arguments onto the upstream request query string. A converter binds a `model` to a registered `catalog` subject. Properties present in the resolved schema are emitted as query parameters; absent optionals are omitted.
+
+#### with.body
+
+> `object`
+
+Upstream `http` request body, defined either as a converter projection or as an explicit template.
+
+A converter projects the `tools/call` arguments onto the request body, pruned to the properties in the resolved schema, with absent optionals omitted.
+
+```yaml
+with:
+  body:
+    model: json
+    catalog:
+      my_catalog:
+        - subject: create_pr_body
+          version: latest
+```
+
+#### body.template
+
+> `object` as map of named `string`
+
+Explicit request body, mapping each body property to an interpolated value. Supports `${args.x}` interpolation, where `x` references a property of the `tools/call` arguments. Use a template to rename or restructure arguments before dispatch.
+
+```yaml
+with:
+  body:
+    template:
+      title: ${args.title}
+      head: ${args.branch}
+      base: ${args.target}
+```

--- a/src/reference/config/bindings/mcp-http/.partials/routes.md
+++ b/src/reference/config/bindings/mcp-http/.partials/routes.md
@@ -71,7 +71,7 @@ Tool name to match, referencing an entry in [`options.tools`](#options-tools).
 
 Resource name to match, referencing an entry in [`options.resources`](#options-resources).
 
-#### routes[].with\*
+#### routes[].with
 
 > `object`
 

--- a/src/reference/config/bindings/mcp-http/README.md
+++ b/src/reference/config/bindings/mcp-http/README.md
@@ -9,7 +9,7 @@ tag:
 
 # mcp-http Binding
 
-The `proxy` kind `mcp_http` binding accepts `mcp` streams and produces `http` streams. It terminates `tools/list` and `resources/list` from configuration, and expands `tools/call` and `resources/read` into upstream `http` requests.
+The `proxy` kind `mcp_http` binding accepts `mcp` streams and produces `http` streams. It terminates `tools/list`, `resources/list`, and `prompts/list` from configuration, expands `tools/call` and `resources/read` into upstream `http` requests, and renders `prompts/get` from configured message templates.
 
 ## proxy
 

--- a/src/reference/config/bindings/mcp-http/README.md
+++ b/src/reference/config/bindings/mcp-http/README.md
@@ -1,0 +1,22 @@
+---
+shortTitle: mcp-http
+category:
+  - Binding
+tag:
+  - mcp-http
+  - proxy
+---
+
+# mcp-http Binding
+
+The `proxy` kind `mcp_http` binding accepts `mcp` streams and produces `http` streams. It terminates `tools/list` and `resources/list` from configuration, and expands `tools/call` and `resources/read` into upstream `http` requests.
+
+## proxy
+
+> [Full config](./proxy.md)
+
+Behave as an `mcp_http` `proxy`.
+
+```yaml {3}
+<!-- @include: ./.partials/proxy.yaml -->
+```

--- a/src/reference/config/bindings/mcp-http/proxy.md
+++ b/src/reference/config/bindings/mcp-http/proxy.md
@@ -4,7 +4,7 @@ shortTitle: proxy
 
 # mcp-http proxy
 
-The `mcp_http` proxy binding accepts `mcp` streams and produces `http` streams, terminating `tools/list` and `resources/list` from configuration and expanding `tools/call` and `resources/read` into upstream `http` requests.
+The `mcp_http` proxy binding accepts `mcp` streams and produces `http` streams, terminating `tools/list`, `resources/list`, and `prompts/list` from configuration, expanding `tools/call` and `resources/read` into upstream `http` requests, and rendering `prompts/get` from configured message templates.
 
 ```yaml {3}
 <!-- @include: ./.partials/proxy.yaml -->

--- a/src/reference/config/bindings/mcp-http/proxy.md
+++ b/src/reference/config/bindings/mcp-http/proxy.md
@@ -1,0 +1,18 @@
+---
+shortTitle: proxy
+---
+
+# mcp-http proxy
+
+The `mcp_http` proxy binding accepts `mcp` streams and produces `http` streams, terminating `tools/list` and `resources/list` from configuration and expanding `tools/call` and `resources/read` into upstream `http` requests.
+
+```yaml {3}
+<!-- @include: ./.partials/proxy.yaml -->
+```
+
+## Configuration (\* required)
+
+<!-- @include: ./.partials/options.md -->
+<!-- @include: ./.partials/routes.md -->
+<!-- @include: ../.partials/exit.md -->
+<!-- @include: ../.partials/telemetry.md -->


### PR DESCRIPTION
## Summary

Add comprehensive reference documentation for the `mcp-http` binding, a new proxy binding that accepts MCP streams and produces HTTP streams.

## Changes

- **New binding documentation structure**: Created `src/reference/config/bindings/mcp-http/` directory with complete reference pages following the Diataxis pattern
  - `README.md` — Overview and binding introduction
  - `proxy.md` — Proxy kind configuration page
  - `.partials/proxy.yaml` — Full YAML configuration example
  - `.partials/options.md` — Comprehensive property documentation for `options`, `authorization`, `tools`, and `resources`
  - `.partials/routes.md` — Route matching and HTTP request resolution documentation

- **Sidebar navigation**: Added `mcp-http` binding entry to the reference bindings section in `src/.vuepress/sidebar/en.ts`

## Implementation Details

- Documentation follows the established reference page structure with proper header depth hierarchy matching property nesting
- Property documentation includes type annotations, defaults, and interpolation support (e.g., `${args.x}`, `${params.x}`, `${result.x}`)
- Configuration examples demonstrate:
  - Guard-based authorization with credential injection
  - Tool definitions with input/output schema validation
  - Resource definitions with URI templates and MIME types
  - Route matching with conditional HTTP request resolution
- Uses `@include` directives for YAML examples and property tables, consistent with other binding documentation

https://claude.ai/code/session_01VpDFPY4N4koEX5qpJSDXBR