### PR TITLE
docs(mqtt): document required store on server; add asyncapi options.mqtt.store

### DIFF
--- a/src/reference/config/bindings/asyncapi/.partials/options.md
+++ b/src/reference/config/bindings/asyncapi/.partials/options.md
@@ -107,3 +107,15 @@ Named header value pattern with `{credentials}`, e.g. `"Bearer` `{credentials}"`
 > `object` as map of named `string` properties
 
 Named query parameter value pattern with `{credentials}`.
+
+#### options.mqtt
+
+> `object`
+
+The mqtt specific options applied to the generated [mqtt](../../mqtt/server.md) server, using the same shape as the mqtt binding `options`.
+
+#### mqtt.store
+
+> `string`
+
+The name of a configured [store](../../../stores/memory.md) used to coordinate MQTT session ownership for the generated mqtt server. When omitted, a default store is generated for the server; reference an external or cluster-wide store to share session ownership across Zilla instances.

--- a/src/reference/config/bindings/mqtt/.partials/server.yaml
+++ b/src/reference/config/bindings/mqtt/.partials/server.yaml
@@ -2,6 +2,7 @@
     type: mqtt
     kind: server
     options:
+      store: my_store
       authorization:
         my_jwt_guard:
           credentials:

--- a/src/reference/config/bindings/mqtt/server.md
+++ b/src/reference/config/bindings/mqtt/server.md
@@ -12,7 +12,7 @@ The mqtt server binding decodes the MQTT protocol on the inbound network stream,
 
 ## Configuration (\* required)
 
-### options
+### options\*
 
 > `object`
 
@@ -20,6 +20,7 @@ The `server` specific options.
 
 ```yaml
 options:
+  store: my_store
   authorization:
     my_jwt_guard:
       credentials:
@@ -31,6 +32,17 @@ options:
 ```
 
 <!-- @include: ./.partials/options.md -->
+
+#### options.store\*
+
+> `string`
+
+The name of a configured [store](../../stores/memory.md) used to coordinate MQTT session ownership across connections and Zilla instances. Required for the `server` kind.
+
+```yaml
+options:
+  store: my_store
+```
 
 #### options.authorization
 


### PR DESCRIPTION
## Summary

Follows up [aklivity/zilla#1964](https://github.com/aklivity/zilla/pull/1964) (merged), which made a `store` reference **required** on the `mqtt` server binding for session ownership, and added `options.mqtt.store` to the `asyncapi` binding.

### mqtt server reference
- Mark `options` and the new `options.store` as required (`*`).
- Add `store` to the server YAML example.
- Document `options.store` — references a configured store used to coordinate MQTT session ownership across connections and Zilla instances; required for `kind: server`.

### asyncapi binding reference
- Document `options.mqtt` (the mqtt protocol options applied to the generated mqtt server, same shape as the mqtt binding `options`).
- Document `options.mqtt.store` for referencing an external or cluster-wide store for the generated mqtt server.

## Notes

- Relative links in the asyncapi partial resolve relative to the partial's own location (matching the existing `http/.partials/options.md` → `../../../models/` convention), so they use `../../mqtt/server.md` and `../../../stores/memory.md`.
- `pnpm lint` / `vale` / `lychee` were not run here (the toolchain isn't installed in this environment, and `node_modules` is absent); changes were reviewed manually against the reference-page structure rules.
- `.check-schema/zilla-schema.json` is not updated — it is regenerated from a released Zilla Docker image, so the `store`/`options.mqtt.store` properties will appear once a release including #1964 is published and the schema is refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vx4B6SkggrTs8EEEenxPtp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vx4B6SkggrTs8EEEenxPtp)_