### PR TITLE
docs(openapi): document the specs.overlay option

### DIFF
--- a/src/reference/config/bindings/openapi/.partials/options.md
+++ b/src/reference/config/bindings/openapi/.partials/options.md
@@ -40,6 +40,34 @@ Subject name used when storing the catalog artifact.
 
 Catalog artifact version to use.
 
+#### specs.overlay
+
+> `object` as map of named `object` properties
+
+An [OpenAPI Overlay Specification](https://spec.openapis.org/overlay/v1.0.0.html) document,
+resolved the same way as `catalog`, whose actions are applied to the spec document before it
+is parsed. Use this to patch a spec that comes from a source you cannot edit directly, such as
+a schema registry.
+
+```yaml
+overlay:
+  my_catalog:
+    subject: petstore-overlay
+    version: latest
+```
+
+#### overlay.subject\*
+
+> `string`
+
+Subject name used when storing the overlay artifact.
+
+#### overlay.version
+
+> `string` | Default: `latest`
+
+Overlay artifact version to use.
+
 #### specs.servers
 
 > `array` of `object`


### PR DESCRIPTION
## Description

Zilla's `openapi` binding now supports an `options.specs.<label>.overlay` option: an [OpenAPI Overlay Specification](https://spec.openapis.org/overlay/v1.0.0.html) document, resolved the same way as `specs.<label>.catalog`, whose actions are applied to the spec before it's parsed. Documents this new option in the `openapi` binding reference, mirroring the existing `catalog` property docs.

Companion runtime change: aklivity/zilla#2130 (fixes aklivity/zilla#2127).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vpc6Hy3Vkd7wtxDBwnybvw)_