### PR TITLE
docs: document kafka-proxy topics[].alias and the aws-cognito guard

### DIFF
--- a/src/reference/config/bindings/kafka-proxy/.partials/options.md
+++ b/src/reference/config/bindings/kafka-proxy/.partials/options.md
@@ -151,7 +151,7 @@ Topic name, as observed by the external client.
 
 > `string`
 
-Template for the internal topic name. Supports `${topic}` to reference the topic's own `name`, along with identity and attribute placeholders such as `${guarded['my_guard'].identity}` and `${guarded['my_guard'].attributes.my_attribute}`. When omitted, the internal topic name matches the external name.
+Template for the internal topic name. Supports `${topic}` to reference the topic's own `name`, along with identity and attribute placeholders such as `${guarded['my_guard'].identity}` and `${guarded['my_guard'].attributes.my_attribute}`. When omitted, the existing rules apply, either cluster-id prefixed or match the external name.
 
 ```yaml
 topics:

--- a/src/reference/config/bindings/kafka-proxy/.partials/options.md
+++ b/src/reference/config/bindings/kafka-proxy/.partials/options.md
@@ -145,7 +145,19 @@ Topic configuration list.
 
 > `string`
 
-Topic name.
+Topic name, as observed by the external client.
+
+#### topics[].alias
+
+> `string`
+
+Template for the internal topic name. Supports `${topic}` to reference the topic's own `name`, along with identity and attribute placeholders such as `${guarded['my_guard'].identity}` and `${guarded['my_guard'].attributes.my_attribute}`. When omitted, the internal topic name matches the external name.
+
+```yaml
+topics:
+  - name: messages
+    alias: "${topic}-${guarded['my_guard'].identity}"
+```
 
 #### topics[].key
 

--- a/src/reference/config/bindings/kafka-proxy/.partials/routes.md
+++ b/src/reference/config/bindings/kafka-proxy/.partials/routes.md
@@ -22,12 +22,6 @@ Topic name to match.
 
 Kafka API keys to match.
 
-#### routes[].with
-
-> `object`
-
-Properties applied when following this route.
-
 #### routes[].guarded
 
 > `object` as map of named `array` of `string`

--- a/src/reference/config/guards/aws-cognito.md
+++ b/src/reference/config/guards/aws-cognito.md
@@ -32,8 +32,6 @@ guards:
 
 ## Configuration (\* required)
 
-<!-- @include: ./.partials/store.md -->
-
 ### options\*
 
 > `object`

--- a/src/reference/config/guards/aws-cognito.md
+++ b/src/reference/config/guards/aws-cognito.md
@@ -1,0 +1,95 @@
+---
+shortTitle: aws-cognito
+category:
+  - Guard
+tag:
+  - aws-cognito
+---
+
+# aws-cognito Guard
+
+[Available in <ZillaPlus/>](https://www.aklivity.io/products/zilla-plus)
+{.zilla-plus-badge .hint-container .info}
+
+Defines a guard with `AWS Cognito` support.
+
+The `aws-cognito` guard uses public keys to verify the integrity of access tokens issued by an AWS Cognito user pool when identifying authorized subjects and their associated roles scope. The token issuer, client ID, and audience can also be constrained to prevent access tokens from other applications from being reused inappropriately.
+
+Each verified access token has an expiration time, and specific protocol bindings can use it to determine when a client's authorization needs to be renewed.
+
+Public keys are discovered automatically from the user pool's `.well-known/openid-configuration` and `.well-known/jwks.json` endpoints.
+
+```yaml {2}
+guards:
+  my_aws_cognito_guard:
+    type: aws-cognito
+    options:
+      pool: arn:aws:cognito-idp:us-east-1:012345678901:userpool/us-east-1_ABC123XYZ
+      client-id: "*"
+```
+
+`options` must set `client-id` and/or `audience`. `client-id` gates acceptance of tokens by their `token_use: access` shape, validated against the `client_id` claim — the shape `client_credentials`-grant tokens have, since they carry no `aud` claim at all.
+
+## Configuration (\* required)
+
+<!-- @include: ./.partials/store.md -->
+
+### options\*
+
+> `object`
+
+The `aws-cognito` specific options.
+
+```yaml
+options:
+  pool: arn:aws:cognito-idp:us-east-1:012345678901:userpool/us-east-1_ABC123XYZ
+  region: us-east-1
+  client-id: "*"
+  audience: https://api.example.com
+  roles: cognito:groups
+  identity: sub
+  attributes:
+    tenant: custom:tenant
+```
+
+#### options.pool\*
+
+> `string`
+
+The Cognito user pool, given as a full ARN (`arn:aws:cognito-idp:<region>:<account-id>:userpool/<pool-id>`), a full pool ID (`<region>_<suffix>`), or just the pool ID suffix. When only the suffix is given, `region` must be set, or resolvable from the AWS default region provider chain.
+
+#### options.region
+
+> `string`
+
+AWS region of the user pool. Overrides any region encoded in `pool`, and is required when `pool` is given as just the pool ID suffix and no default region is otherwise resolvable.
+
+#### options.client-id
+
+> `string`, `array` of `string`
+
+Client ID(s) to accept, matched against the token's `client_id` claim. Use `*` to accept any client ID. At least one of `client-id` or `audience` is required.
+
+#### options.audience
+
+> `string`, `array` of `string`
+
+Audience claim(s) to accept. At least one of `client-id` or `audience` is required.
+
+#### options.roles
+
+> `string` | Default: `cognito:groups`
+
+Claim to check for authorized roles.
+
+#### options.identity
+
+> `string` | Default: `sub`
+
+Claim to extract the user's identity from the token.
+
+#### options.attributes
+
+> `object` as map of named `string` properties
+
+Additional claims to extract from the token as named attributes.

--- a/src/reference/config/overview.md
+++ b/src/reference/config/overview.md
@@ -138,13 +138,14 @@ Guards can be used by specific protocol bindings to enforce authorization requir
 
 Associated roles can be enforced during routing by only following routes `guarded` by specific role requirements when authorized. This implicitly supports falling through to lower privilege routes when `guarded` higher privilege routes are not authorized.
 
-| Type                                   | Purpose                                                                                 |
-|----------------------------------------|-----------------------------------------------------------------------------------------|
-| [`jwt`](./guards/jwt.md)               | Validates JWT bearer tokens against JWKS. Extracts roles for route authorization.       |
-| [`api-keys`](./guards/api-keys.md)     | Validates API keys against a static list or a store. `[Plus]`                           |
-| [`azure-ad`](./guards/azure-ad.md)     | Validates Azure Active Directory OAuth2 tokens. `[Plus]`                                |
-| [`aws-lambda`](./guards/aws-lambda.md) | Delegates authorization to an AWS Lambda function. `[Plus]`                             |
-| [`identity`](./guards/identity.md)     | Pass-through guard; approves all requests. Used for testing or default routes. `[Plus]` |
+| Type                                     | Purpose                                                                                 |
+|------------------------------------------|-----------------------------------------------------------------------------------------|
+| [`jwt`](./guards/jwt.md)                 | Validates JWT bearer tokens against JWKS. Extracts roles for route authorization.       |
+| [`api-keys`](./guards/api-keys.md)       | Validates API keys against a static list or a store. `[Plus]`                           |
+| [`azure-ad`](./guards/azure-ad.md)       | Validates Azure Active Directory OAuth2 tokens. `[Plus]`                                |
+| [`aws-cognito`](./guards/aws-cognito.md) | Validates AWS Cognito OAuth2 access tokens. `[Plus]`                                    |
+| [`aws-lambda`](./guards/aws-lambda.md)   | Delegates authorization to an AWS Lambda function. `[Plus]`                             |
+| [`identity`](./guards/identity.md)       | Pass-through guard; approves all requests. Used for testing or default routes. `[Plus]` |
 
 ### vaults
 


### PR DESCRIPTION
## Summary

- **kafka-proxy binding**: the `routes[].with.topic` per-topic name-rewrite template moved to `options.topics[].alias` in [aklivity/zilla-plus#1035](https://github.com/aklivity/zilla-plus/pull/1035) (merged). Updates the reference docs to match:
  - `.partials/routes.md`: drops the now-removed `routes[].with` property.
  - `.partials/options.md`: documents the new `topics[].alias` property (template grammar, default behavior when omitted), and clarifies `topics[].name` is the topic as observed by the external client.
- **aws-cognito guard**: adds the reference page for this guard, which had no docs yet. Modeled on the existing `jwt`/`azure-ad` guard pages (nearest equivalents — JWT validation with automatic JWKS discovery), verified against the actual `guard-aws-cognito` schema and config classes in zilla-plus (`pool`/`region`/`client-id`/`audience`/`roles`/`identity`/`attributes`, plus the ARN/pool-ID resolution rules for `pool`). Adds it to the guards overview table.

## Test plan

- [x] `pnpm i` + `npx markdownlint-cli2` on all changed/added files — 0 errors
- [ ] Vale / Lychee — not available in this environment, not run


---
_Generated by [Claude Code](https://claude.ai/code/session_011LfmguC5M5mwdLJ64Dxruk)_