### PR TITLE
docs(kafka-proxy): document oauthbearer mechanism on internal.authorization

### DIFF
--- a/src/reference/config/bindings/kafka-proxy/.partials/options.md
+++ b/src/reference/config/bindings/kafka-proxy/.partials/options.md
@@ -138,21 +138,38 @@ Authorization configuration for internal connections.
 
 #### credentials.mechanism
 
-> `enum` [ `plain`, `scram-sha-256`, `scram-sha-512` ]
+> `enum` [ `plain`, `scram-sha-256`, `scram-sha-512`, `oauthbearer` ]
 
 Authentication mechanism.
 
-#### credentials.username\*
+- `plain`, `scram-sha-256`, `scram-sha-512`: authenticates to the internal broker with the static `username`/`password` below.
+- `oauthbearer`: authenticates to the internal broker with a token built from the `credentials` template below, evaluated against the session an external guard already authorized. Lets Zilla present the external client's own credentials to the internal broker instead of a static service-account secret.
+
+#### credentials.username
 
 > `string`
 
-Username for authentication.
+Username for authentication. Required when `mechanism` is `plain`, `scram-sha-256`, or `scram-sha-512`.
 
-#### credentials.password\*
+#### credentials.password
 
 > `string`
 
-Password for authentication.
+Password for authentication. Required when `mechanism` is `plain`, `scram-sha-256`, or `scram-sha-512`.
+
+#### credentials.credentials
+
+> `string`
+
+Template used to build the bearer token presented to the internal broker. Required when `mechanism` is `oauthbearer`. Supports `${guarded['my_guard'].credentials}` to reference the raw credential string an external guard authorized the session with.
+
+```yaml
+internal:
+  authorization:
+    credentials:
+      mechanism: oauthbearer
+      credentials: "Bearer ${guarded['cognito0'].credentials}"
+```
 
 #### options.topics
 


### PR DESCRIPTION
## Summary

- `kafka-proxy`'s `internal.authorization.credentials.mechanism` reference table didn't document the new `oauthbearer` option added by `aklivity/zilla-plus#1051`. Adds it alongside `plain`/`scram-sha-256`/`scram-sha-512`, documents the new `credentials.credentials` template property (`${guarded['my_guard'].credentials}`), and clarifies that `username`/`password` are only required for the static mechanisms.
- No other reference pages reference `internal.authorization`, so no other changes were needed.

## Test plan

- [x] `pnpm lint` — the changed file introduces no new violations (all reported lint issues are pre-existing, in unrelated files).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ddn48f5dYPWsnuSCLafaZn)_