### PR TITLE
docs(kafka): remove when.topic route matching from client binding reference

### DIFF
--- a/src/reference/config/bindings/kafka/.partials/routes-client.md
+++ b/src/reference/config/bindings/kafka/.partials/routes-client.md
@@ -1,0 +1,28 @@
+### routes\*
+
+> `array` of `object`
+
+`kafka` specific routes.
+
+#### routes[].guarded
+
+> `object` as map of named `array` of `string`
+
+List of roles required by each named guard to authorize this route.
+
+```yaml
+routes:
+  - guarded:
+      my_guard:
+        - read:items
+```
+
+#### routes[].exit
+
+> `string`
+
+Next binding when following this route.
+
+```yaml
+exit: echo_server
+```

--- a/src/reference/config/bindings/kafka/client.md
+++ b/src/reference/config/bindings/kafka/client.md
@@ -42,6 +42,6 @@ SASL credentials to use when connecting to `kafka` brokers.
 
 <!-- @include: ../.partials/options-kafka-sasl.md -->
 
-<!-- @include: ./.partials/routes.md -->
+<!-- @include: ./.partials/routes-client.md -->
 <!-- @include: ../.partials/exit.md -->
 <!-- @include: ../.partials/telemetry.md -->


### PR DESCRIPTION
## Description

Follow-up to [aklivity/zilla#2200](https://github.com/aklivity/zilla/pull/2200), which removed `when: - topic:` route conditions from `type: kafka, kind: client` bindings (per [aklivity/zilla#2199](https://github.com/aklivity/zilla/issues/2199)).

The `client` binding reference page (`kafka/client.md`) included a `routes.md` partial shared with `cache_client`/`cache_server`, which still documented `routes[].when` / `when[].topic`. Since those kinds are unaffected by the change and keep topic-based routing, this splits out a client-specific partial (`routes-client.md`) documenting only `routes[].guarded` and `routes[].exit`, and points `client.md` at it instead.

No other docs (concepts pages, tutorials, cookbooks, examples) configure a `kafka` `client` binding with `when: topic` routes, so no other content needed updating — verified with a YAML-aware scan of every embedded config in the repo.

## Test plan

- [x] `pnpm lint` — no new violations introduced by the changed files


---
_Generated by [Claude Code](https://claude.ai/code/session_01EcMFWmF4qe5tADhHdueUEg)_