### PR TITLE
docs: update identity guard and kafka-proxy authorization for 2.0 syntax

### DIFF
--- a/src/reference/config/bindings/kafka-proxy/.partials/options.md
+++ b/src/reference/config/bindings/kafka-proxy/.partials/options.md
@@ -33,7 +33,9 @@ external:
   port: 9093
   authorization:
     cognito0:
-      mechanism: oauthbearer
+      credentials:
+        mechanism: oauthbearer
+        token: "{credentials}"
 ```
 
 #### external.host\*
@@ -66,32 +68,61 @@ Radix used to encode the broker number in the external hostname pattern.
 
 Authorization configuration for external connections, keyed by guard name. Each named entry authenticates the external SASL handshake against that guard.
 
+```yaml
+external:
+  authorization:
+    test0:
+      mechanism: plain
+      pattern: "{username}:{password}"
+    cognito0:
+      credentials:
+        mechanism: oauthbearer
+        token: "{credentials}"
+```
+
 #### authorization.mechanism
 
-> `enum` [ `plain`, `oauthbearer` ]
+> `enum` [ `plain`, `scram-sha-256`, `scram-sha-512` ]
 
-Authorization mechanism.
+Extracts `authzid`/`authcid`/`passwd` from a SASL/PLAIN or SASL/SCRAM initial response and substitutes them into the `pattern` template before authorizing with the guard. Required together with `pattern`; mutually exclusive with `credentials`.
 
-- `plain`: extracts `authzid`/`authcid`/`passwd` from a SASL/PLAIN initial response and substitutes them into the `credentials` template before authorizing with the guard.
-- `oauthbearer`: parses an RFC 7628 SASL/OAUTHBEARER initial response and extracts the bearer token, substituting it into the `credentials` template before authorizing with the guard. On rejection, the client receives an RFC 7628 §3.7 error response instead of an immediate SASL failure.
+#### authorization.pattern
 
-#### authorization.credentials
+> `string`
 
-> `string` | Default: `"Bearer {credentials}"` when `mechanism` is `oauthbearer`
-
-Template used to build the credentials string passed to the guard.
-
-- For `plain`, `{username}` and `{password}` are substituted from the SASL/PLAIN initial response's `authcid`/`passwd`. Required.
-- For `oauthbearer`, `{credentials}` is substituted from the extracted bearer token. Optional.
+Template used to build the credentials string passed to the guard, substituting `{username}` and `{password}` from the SASL initial response's `authcid`/`passwd`.
 
 ```yaml
 external:
   authorization:
     test0:
       mechanism: plain
-      credentials: "{username}:{password}"
+      pattern: "{username}:{password}"
+```
+
+#### authorization.credentials
+
+> `object`
+
+Parses an RFC 7628 SASL/OAUTHBEARER initial response and extracts the bearer token before authorizing with the guard. On rejection, the client receives an RFC 7628 §3.7 error response instead of an immediate SASL failure. Mutually exclusive with `mechanism`/`pattern`.
+
+#### credentials.mechanism\*
+
+> `const` `oauthbearer`
+
+#### credentials.token\*
+
+> `string`
+
+Kept for symmetry with `internal.authorization.credentials.token`; its value is not read. The bearer token is always the content following the `"Bearer "` prefix in the SASL/OAUTHBEARER initial response.
+
+```yaml
+external:
+  authorization:
     cognito0:
-      mechanism: oauthbearer
+      credentials:
+        mechanism: oauthbearer
+        token: "{credentials}"
 ```
 
 #### options.internal\*
@@ -132,43 +163,59 @@ Radix used to encode the broker number in the internal hostname pattern.
 
 #### internal.authorization
 
-> `object`
+> `object` as map of named `object` properties
 
-Authorization configuration for internal connections.
-
-#### credentials.mechanism
-
-> `enum` [ `plain`, `scram-sha-256`, `scram-sha-512`, `oauthbearer` ]
-
-Authentication mechanism.
-
-- `plain`, `scram-sha-256`, `scram-sha-512`: authenticates to the internal broker with the static `username`/`password` below.
-- `oauthbearer`: authenticates to the internal broker with a token built from the `credentials` template below, evaluated against the session an external guard already authorized. Lets Zilla present the external client's own credentials to the internal broker instead of a static service-account secret.
-
-#### credentials.username
-
-> `string`
-
-Username for authentication. Required when `mechanism` is `plain`, `scram-sha-256`, or `scram-sha-512`.
-
-#### credentials.password
-
-> `string`
-
-Password for authentication. Required when `mechanism` is `plain`, `scram-sha-256`, or `scram-sha-512`.
-
-#### credentials.credentials
-
-> `string`
-
-Template used to build the bearer token presented to the internal broker. Required when `mechanism` is `oauthbearer`. Supports `${guarded['my_guard'].credentials}` to reference the raw credential string an external guard authorized the session with.
+Authorization configuration for internal connections, keyed by guard name, structurally identical to `external.authorization`. The internal and external guard names may differ; when both reference the same guard, the credentials an external guard authorized the external SASL handshake with are reused to authenticate to the internal broker, instead of a static service-account secret.
 
 ```yaml
 internal:
   authorization:
-    credentials:
-      mechanism: oauthbearer
-      credentials: "Bearer ${guarded['cognito0'].credentials}"
+    cognito0:
+      credentials:
+        mechanism: oauthbearer
+        token: "{credentials}"
+    svc0:
+      credentials:
+        mechanism: plain
+        username: "{identity}"
+        password: "{credentials}"
+```
+
+#### credentials.mechanism
+
+> `enum` [ `oauthbearer`, `plain`, `scram-sha-256`, `scram-sha-512` ]
+
+Authentication mechanism used against the internal broker.
+
+- `oauthbearer`: builds the bearer token from `token`, evaluated against `guard.credentials(sessionId)` for the session the external side already authorized.
+- `plain`, `scram-sha-256`, `scram-sha-512`: builds the username from `username`, evaluated against `guard.identity(sessionId)`, and the password from `password`, evaluated against `guard.credentials(sessionId)`.
+
+#### credentials.token
+
+> `string` | Default: `"{credentials}"` when `mechanism` is `oauthbearer`
+
+Template for the bearer token. When the value is exactly `{credentials}`, it is substituted with the guard's raw credential string for the session; any other literal value passes through unchanged with no guard interaction. Optional; omitting it entirely behaves as if set to `{credentials}`.
+
+#### credentials.username\*
+
+> `string`
+
+Username for `plain`, `scram-sha-256`, or `scram-sha-512`. When the value is exactly `{identity}`, it is substituted with the guard's identity for the session; any other literal value passes through unchanged with no guard interaction. Required.
+
+#### credentials.password\*
+
+> `string`
+
+Password for `plain`, `scram-sha-256`, or `scram-sha-512`. When the value is exactly `{credentials}`, it is substituted with the guard's raw credential string for the session; any other literal value passes through unchanged with no guard interaction. Required.
+
+```yaml
+internal:
+  authorization:
+    svc0:
+      credentials:
+        mechanism: plain
+        username: "{identity}"
+        password: "{credentials}"
 ```
 
 #### options.topics

--- a/src/reference/config/guards/identity.md
+++ b/src/reference/config/guards/identity.md
@@ -24,3 +24,49 @@ guards:
 ## Configuration (\* required)
 
 <!-- @include: ./.partials/store.md -->
+
+### options
+
+> `object`
+
+The `identity` guard specific options.
+
+```yaml
+options:
+  format: "{identity}:{credentials}"
+  identity: zilla-service-account
+  credentials: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
+```
+
+#### options.format
+
+> `string`
+
+Pattern for splitting the credential string presented at authorization into an identity part and a credentials part, resolved independently by downstream bindings, for example a `kafka` `client` binding's `username: "{identity}"` and `password: "{credentials}"`. Without `format`, the whole credential string is used as the identity, and the same value is also returned as the credentials, since there is nothing to split.
+
+```yaml
+options:
+  format: "{identity}:{credentials}"
+```
+
+#### options.identity
+
+> `string`
+
+A static identity value returned when no session is active.
+
+```yaml
+options:
+  identity: zilla-service-account
+```
+
+#### options.credentials
+
+> `string`
+
+A static credential value returned when no session is active. Useful for supplying a fixed credential, such as a pre-signed JWT, to a downstream binding without an active upstream session.
+
+```yaml
+options:
+  credentials: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
+```


### PR DESCRIPTION
## Summary

Recreates #408 against `support/2.x` — that PR was opened against `develop` in error and has been reverted there (`a428337`).

Updates two reference pages to match config changes shipping in [aklivity/zilla#2202](https://github.com/aklivity/zilla/pull/2202) and [aklivity/zilla-plus#1064](https://github.com/aklivity/zilla-plus/pull/1064) (both unreleased, targeting 2.0).

**`identity` guard** (`src/reference/config/guards/identity.md`): adds a `Configuration` → `options` section that was previously entirely missing — the `identity`/`credentials` static fallback values were undocumented even before this change — plus the new `options.format` for splitting a compound credential into independently-resolvable identity and credentials parts.

**`kafka-proxy` binding** (`.partials/options.md`): rewrites `external.authorization` and `internal.authorization` to match the aligned syntax:
- oauthbearer (both sides) nests `mechanism` inside a `credentials` object with a bare `token` field, matching `binding-kafka`'s existing shape.
- external plain/scram renames its wire-matching template field from `credentials` to `pattern`.
- internal plain/scram now documents the `username`/`password` split, each resolved independently against `guard.identity()`/`guard.credentials()`.

Note: the prior `internal.authorization` docs described a static `credentials.{username,password}` shape that predates the #1055/#1056 guard-name-keyed restructure in `zilla-plus` — they were already out of date before this change, not just affected by it.

## Test plan

- Cherry-picked cleanly from the original commit onto `support/2.x` with no conflicts.
- `pnpm lint` — clean on both changed files.
- Content cross-checked directly against the shipped JSON schema patches in the linked `zilla-plus` PR (`kafka-proxy.schema.patch.json`) to confirm every documented shape, required/optional field, and default matches exactly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfdZXUbAuFm2nediVssqoM)_