### PR TITLE
docs(mcp-kafka): add mcp-kafka binding reference

### DIFF
--- a/src/.vuepress/sidebar/en.ts
+++ b/src/.vuepress/sidebar/en.ts
@@ -125,6 +125,13 @@ export const enSidebar = sidebar({
           children: "structure",
         },
         {
+          text: "MCP-Kafka",
+          icon: "fa-solid fa-robot",
+          prefix: "mcp-kafka",
+          collapsible: true,
+          children: "structure",
+        },
+        {
           text: "MCP-OpenAPI",
           icon: "fa-solid fa-robot",
           prefix: "mcp-openapi",

--- a/src/reference/config/bindings/mcp-kafka/.partials/client.yaml
+++ b/src/reference/config/bindings/mcp-kafka/.partials/client.yaml
@@ -1,0 +1,33 @@
+mcp_kafka_client:
+  type: mcp_kafka
+  kind: client
+  options:
+    servers:
+      - kafka.examples.dev:9092
+  routes:
+    - when:
+        - tool: create_topics
+        - tool: delete_topics
+        - tool: alter_configs
+        - tool: reset_offsets
+      guarded:
+        my_guard:
+          - kafka:admin
+    - when:
+        - tool: produce
+          topics: [ orders ]
+      guarded:
+        my_guard:
+          - kafka:write
+    - when:
+        - tool: consume
+          topics: [ orders ]
+    - when:
+        - tool: describe_configs
+        - tool: list_topics
+        - tool: describe_topic
+        - tool: cluster_overview
+        - tool: list_brokers
+        - tool: describe_cluster
+        - tool: list_consumer_groups
+        - tool: describe_consumer_group

--- a/src/reference/config/bindings/mcp-kafka/.partials/options.md
+++ b/src/reference/config/bindings/mcp-kafka/.partials/options.md
@@ -1,0 +1,74 @@
+### options\*
+
+> `object`
+
+The `client` specific options.
+
+```yaml
+options:
+  servers:
+    - kafka.examples.dev:9092
+  authorization:
+    my_auth:
+      credentials:
+        mechanism: plain
+        username: my_username
+        password: my_password
+  topics:
+    - name: orders
+```
+
+#### options.servers\*
+
+> `array` of `string`
+
+Bootstrap servers to use when connecting to the `kafka` cluster.
+
+#### options.authorization
+
+> `object` as map of named `object`
+
+Credentials used to authenticate this binding's own connection to the `kafka` cluster, keyed by an arbitrary name. At most one entry is allowed.
+
+#### authorization.credentials\*
+
+> `object`
+
+```yaml
+credentials:
+  mechanism: plain
+  username: my_username
+  password: my_password
+```
+
+#### credentials.mechanism\*
+
+> `enum` [ `plain`, `scram-sha-1`, `scram-sha-256`, `scram-sha-512`, `oauthbearer` ]
+
+SASL mechanism used to authenticate with the broker.
+
+#### credentials.username\*
+
+> `string`
+
+SASL username. Required when `mechanism` is `plain` or a `scram-sha-*` variant; not allowed with `oauthbearer`.
+
+#### credentials.password\*
+
+> `string`
+
+SASL password. Required when `mechanism` is `plain` or a `scram-sha-*` variant; not allowed with `oauthbearer`.
+
+#### credentials.token\*
+
+> `string`
+
+SASL token. Required when `mechanism` is `oauthbearer`; not allowed with any other mechanism.
+
+#### options.topics
+
+> `array` of `object`
+
+Per-topic key and value validation, applied to `produce` calls and to records read back by `consume`.
+
+<!-- @include: ../.partials/options-kafka-topics.md -->

--- a/src/reference/config/bindings/mcp-kafka/.partials/routes.md
+++ b/src/reference/config/bindings/mcp-kafka/.partials/routes.md
@@ -1,0 +1,58 @@
+### routes\*
+
+> `array` of `object`
+
+Conditional `mcp_kafka` specific routes, matching by tool name and, for `produce` and `consume`, by topic. At least one route is required. Routes are evaluated in order; the first matching route wins.
+
+```yaml
+routes:
+  - when:
+      - tool: produce
+        topics: [ orders ]
+    guarded:
+      my_guard:
+        - kafka:write
+  - when:
+      - tool: consume
+        topics: [ orders ]
+```
+
+#### routes[].when
+
+> `array` of `object`
+
+List of conditions (any match) restricting this route to particular tools.
+
+```yaml
+routes:
+  - when:
+      - tool: create_topics
+      - tool: delete_topics
+```
+
+#### when[].tool
+
+> `string`
+
+Tool name matched by `tools/call`. Omit to match every tool not already claimed by an earlier route.
+
+#### when[].topics
+
+> `array` of `string`
+
+Topic name allow-list (exact names or `*` glob patterns) restricting this route to matching topics. Only enforced for [`produce`](./client.md#produce) and [`consume`](./client.md#consume), the only two tools that name a single topic as a routing key — every other tool either takes no topic or names one as a `tools/call` argument rather than a route match, so this list has no effect on them.
+
+#### routes[].guarded
+
+> `object` as map of named `array` of `string`
+
+Roles required by the named guard for a `tools/call` against this route. Roles for the same guard are unioned into one entry; roles naming a different guard add a separate entry that must also authorize.
+
+```yaml
+routes:
+  - when:
+      - tool: alter_configs
+    guarded:
+      my_guard:
+        - kafka:admin
+```

--- a/src/reference/config/bindings/mcp-kafka/.partials/routes.md
+++ b/src/reference/config/bindings/mcp-kafka/.partials/routes.md
@@ -40,7 +40,7 @@ Tool name matched by `tools/call`. Omit to match every tool not already claimed 
 
 > `array` of `string`
 
-Topic name allow-list (exact names or `*` glob patterns) restricting this route to matching topics. Only enforced for [`produce`](./client.md#produce) and [`consume`](./client.md#consume), the only two tools that name a single topic as a routing key — every other tool either takes no topic or names one as a `tools/call` argument rather than a route match, so this list has no effect on them.
+Topic name allow-list (exact names or `*` glob patterns) restricting this route to matching topics. Only enforced for [`produce`](../client.md#produce) and [`consume`](../client.md#consume), the only two tools that name a single topic as a routing key — every other tool either takes no topic or names one as a `tools/call` argument rather than a route match, so this list has no effect on them.
 
 #### routes[].guarded
 

--- a/src/reference/config/bindings/mcp-kafka/.partials/tools.md
+++ b/src/reference/config/bindings/mcp-kafka/.partials/tools.md
@@ -1,0 +1,272 @@
+The `mcp_kafka` client exposes a fixed set of intrinsic tools — there is no `options.tools` to author, and no upstream server or spec to derive them from. Each tool's `inputSchema` validates `tools/call` `arguments` before Zilla dispatches the matching Kafka request; a tool with no declared `outputSchema` still returns a result, either as `structuredContent` or as `content` text only.
+
+### produce
+
+> Not read-only, not idempotent
+
+Appends one record to a topic.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `topic` | `string` | Yes | Topic to write to. |
+| `value` | `string` | Yes | Record value. |
+| `key` | `string` | No | Record key. |
+| `partition` | `integer` | No | Explicit partition, chosen automatically when omitted. |
+
+No `outputSchema` is declared; the result is a `content` text summary only.
+
+### consume
+
+> Read-only, idempotent
+
+Reads records from a topic starting at an offset, streaming each record to the reply as it arrives.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `topic` | `string` | Yes | Topic to read from. |
+| `partition` | `integer` | No | Specific partition to read, every partition when omitted. |
+| `offset` | `integer` | No | Starting offset, the earliest available record when omitted. |
+| `limit` | `integer` | No | Maximum records to return (1-100, default 10). |
+
+No `outputSchema` is declared, though the result's `structuredContent` follows this shape:
+
+```json
+{
+  "topic": "orders",
+  "messages": [
+    { "key": null, "headers": [], "value": "hello from mcp-kafka" }
+  ],
+  "count": 1
+}
+```
+
+### create_topics
+
+> Not destructive
+
+Creates one or more topics.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `topics` | `array` of `object` | Yes | Topics to create. |
+| `topics[].name` | `string` | Yes | Topic name. |
+| `topics[].partitions` | `integer` | Yes | Partition count. |
+| `topics[].replicas` | `integer` | Yes | Replication factor. |
+| `topics[].assignments` | `array` | No | Explicit partition-to-broker placement. |
+| `topics[].configs` | `object` | No | Per-topic config overrides. |
+| `timeout` | `integer` | No | Request timeout, in milliseconds. |
+| `validate_only` | `boolean` | No | Validate the request without creating any topic. |
+
+`outputSchema`:
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `topics` | `array` of `object` | Yes | One entry per requested topic. |
+| `topics[].name` | `string` | Yes | Topic name. |
+| `topics[].error` | `integer` | Yes | Kafka error code, `0` on success. |
+| `topics[].error_message` | `string` | No | Kafka error message, present only on failure. |
+
+### delete_topics
+
+> Not read-only, not idempotent
+
+Deletes one or more topics by name.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `topics` | `array` of `string` | Yes | Topic names to delete. |
+| `timeout` | `integer` | No | Request timeout, in milliseconds. |
+
+`outputSchema` — same shape as [`create_topics`](#create-topics):
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `topics` | `array` of `object` | Yes | One entry per requested topic. |
+| `topics[].name` | `string` | Yes | Topic name. |
+| `topics[].error` | `integer` | Yes | Kafka error code, `0` on success. |
+| `topics[].error_message` | `string` | No | Kafka error message, present only on failure. |
+
+### describe_configs
+
+> Read-only, idempotent
+
+Reads the effective configuration of a topic or broker, including values Kafka set by default.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `resource_type` | `enum` [ `topic`, `broker` ] | Yes | Resource kind to describe. |
+| `resource_name` | `string` | Yes | Resource name — a topic name, or a broker id. |
+
+`outputSchema`:
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `configs` | `array` of `object` | Yes | Every config Kafka reports for the resource. |
+| `configs[].name` | `string` | Yes | Config key. |
+| `configs[].value` | `string` | No | Config value. |
+| `configs[].is_default` | `boolean` | Yes | Whether the value is a broker default rather than an explicit override. |
+| `configs[].is_sensitive` | `boolean` | Yes | Whether Kafka redacted the value. |
+
+### alter_configs
+
+> Not destructive
+
+Sets configs on a topic or broker.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `resource_type` | `enum` [ `topic`, `broker` ] | Yes | Resource kind to alter. |
+| `resource_name` | `string` | Yes | Resource name — a topic name, or a broker id. |
+| `configs` | `object` as map of named `string` | Yes | Config keys and their new values. |
+
+`outputSchema`:
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `resource_type` | `enum` [ `topic`, `broker` ] | Yes | Resource kind altered. |
+| `resource_name` | `string` | Yes | Resource name altered. |
+| `updated` | `boolean` | Yes | Whether the change was applied. |
+
+### list_topics
+
+> Read-only, idempotent
+
+Lists every topic on the broker, with each entry's own partition count and replication factor.
+
+No arguments.
+
+`outputSchema`:
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `topics` | `array` of `object` | Yes | One entry per topic on the broker. |
+| `topics[].name` | `string` | Yes | Topic name. |
+| `topics[].partition_count` | `integer` | Yes | Partition count. |
+| `topics[].replication_factor` | `integer` | Yes | Replication factor. |
+
+### describe_topic
+
+> Read-only, idempotent
+
+Describes one topic by name, reporting each partition's leader, replica set, and in-sync replica (ISR) set.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `topic` | `string` | Yes | Topic to describe. |
+
+`outputSchema`:
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `string` | Yes | Topic name. |
+| `partitions` | `array` of `object` | Yes | One entry per partition. |
+| `partitions[].partition_id` | `integer` | Yes | Partition id. |
+| `partitions[].leader` | `integer` | Yes | Broker id of the current leader. |
+| `partitions[].replicas` | `array` of `integer` | Yes | Broker ids holding a replica. |
+| `partitions[].isr` | `array` of `integer` | Yes | Broker ids currently in sync. |
+
+### cluster_overview
+
+> Read-only, idempotent
+
+Summarizes the whole cluster — broker count, controller broker id, and under-replicated and offline partition counts — as a single health check across every topic at once.
+
+No arguments.
+
+`outputSchema`:
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `broker_count` | `integer` | Yes | Number of brokers in the cluster. |
+| `controller_id` | `integer` | Yes | Broker id of the current controller. |
+| `under_replicated_partitions` | `integer` | Yes | Partitions with fewer in-sync replicas than configured. |
+| `offline_partitions` | `integer` | Yes | Partitions with no available leader. |
+| `topic_count` | `integer` | Yes | Number of topics in the cluster. |
+
+### list_brokers
+
+> Read-only, idempotent
+
+Lists every broker in the cluster.
+
+No arguments.
+
+`outputSchema`:
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `brokers` | `array` of `object` | Yes | One entry per broker. |
+| `brokers[].broker_id` | `integer` | Yes | Broker id. |
+| `brokers[].host` | `string` | Yes | Broker host. |
+| `brokers[].port` | `integer` | Yes | Broker port. |
+| `brokers[].rack` | `string` | No | Broker rack id, when configured. |
+
+### describe_cluster
+
+> Read-only, idempotent
+
+Reports the cluster id and the controller broker's id.
+
+No arguments.
+
+`outputSchema`:
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `cluster_id` | `string` | No | KRaft-generated cluster identifier. |
+| `controller_id` | `integer` | Yes | Broker id of the current controller. |
+| `authorized_operations` | `integer` | Yes | Bitfield of operations the connection is authorized to perform on the cluster. |
+
+### list_consumer_groups
+
+> Read-only, idempotent
+
+Lists every consumer group known to the cluster.
+
+No arguments.
+
+`outputSchema`:
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `groups` | `array` of `object` | Yes | One entry per consumer group. |
+| `groups[].group_id` | `string` | Yes | Consumer group id. |
+| `groups[].state` | `string` | Yes | Group state, such as `Stable` or `Dead`. |
+
+### describe_consumer_group
+
+> Read-only, idempotent
+
+Describes one consumer group by id, including its current members and their partition assignments. A group id that has never committed an offset reports state `Dead` — Kafka's actual behavior for a group that does not yet exist, not an error.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `group_id` | `string` | Yes | Consumer group to describe. |
+
+`outputSchema`:
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `group_id` | `string` | Yes | Consumer group id. |
+| `state` | `string` | Yes | Group state, such as `Stable` or `Dead`. |
+| `members` | `array` of `object` | Yes | One entry per group member. |
+| `members[].member_id` | `string` | Yes | Member id. |
+| `members[].client_id` | `string` | Yes | Client id reported by the member. |
+| `members[].assignments` | `array` of `object` | No | Partitions assigned to this member. |
+| `members[].assignments[].topic` | `string` | Yes | Assigned topic. |
+| `members[].assignments[].partition` | `integer` | Yes | Assigned partition. |
+
+### reset_offsets
+
+> Not read-only, not idempotent
+
+Commits an explicit offset for a consumer group on one topic-partition, overwriting whatever the group last committed.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `group` | `string` | Yes | Consumer group to commit for. |
+| `topic` | `string` | Yes | Topic of the partition to commit. |
+| `partition` | `integer` | Yes | Partition to commit. |
+| `offset` | `integer` | Yes | Offset to commit. |
+
+No `outputSchema` is declared; the result is a `content` text summary only.

--- a/src/reference/config/bindings/mcp-kafka/README.md
+++ b/src/reference/config/bindings/mcp-kafka/README.md
@@ -1,0 +1,22 @@
+---
+shortTitle: mcp-kafka
+category:
+  - Binding
+tag:
+  - mcp-kafka
+  - client
+---
+
+# mcp-kafka Binding
+
+The `client` kind `mcp_kafka` binding exposes a fixed set of Kafka broker operations — producing and consuming records, managing topics and their configs, and inspecting brokers and consumer groups — as intrinsic MCP tools, generating its own `kafka_cache_client` / `kafka_client` / `tcp_client` pipeline directly from `options.servers`, with no upstream MCP or REST server and no per-tool schema authoring.
+
+## client
+
+> [Full config](./client.md)
+
+Behave as an `mcp_kafka` `client`.
+
+```yaml {3}
+<!-- @include: ./.partials/client.yaml -->
+```

--- a/src/reference/config/bindings/mcp-kafka/README.md
+++ b/src/reference/config/bindings/mcp-kafka/README.md
@@ -9,7 +9,7 @@ tag:
 
 # mcp-kafka Binding
 
-The `client` kind `mcp_kafka` binding exposes a fixed set of Kafka broker operations — producing and consuming records, managing topics and their configs, and inspecting brokers and consumer groups — as intrinsic MCP tools, generating its own `kafka_cache_client` / `kafka_client` / `tcp_client` pipeline directly from `options.servers`, with no upstream MCP or REST server and no per-tool schema authoring.
+The `client` kind `mcp_kafka` binding exposes a fixed set of Kafka broker operations — producing and consuming records, managing topics and their configs, and inspecting brokers and consumer groups — as intrinsic MCP tools, connecting directly to the Kafka cluster named by `options.servers`, with no upstream MCP or REST server and no per-tool schema authoring.
 
 ## client
 

--- a/src/reference/config/bindings/mcp-kafka/client.md
+++ b/src/reference/config/bindings/mcp-kafka/client.md
@@ -1,0 +1,22 @@
+---
+shortTitle: client
+---
+
+# mcp-kafka client
+
+The `mcp_kafka` client binding exposes a fixed set of Kafka broker operations as intrinsic MCP tools, generating its own `kafka_cache_client` / `kafka_client` / `tcp_client` pipeline directly from `options.servers` — unlike `mcp_openapi` or `mcp_schema_registry`, there is no upstream server, spec, or per-tool schema to author.
+
+```yaml {3}
+<!-- @include: ./.partials/client.yaml -->
+```
+
+## Configuration (\* required)
+
+<!-- @include: ./.partials/options.md -->
+<!-- @include: ./.partials/routes.md -->
+<!-- @include: ../.partials/exit.md -->
+<!-- @include: ../.partials/telemetry.md -->
+
+## Tools
+
+<!-- @include: ./.partials/tools.md -->

--- a/src/reference/config/bindings/mcp-kafka/client.md
+++ b/src/reference/config/bindings/mcp-kafka/client.md
@@ -4,7 +4,7 @@ shortTitle: client
 
 # mcp-kafka client
 
-The `mcp_kafka` client binding exposes a fixed set of Kafka broker operations as intrinsic MCP tools, generating its own `kafka_cache_client` / `kafka_client` / `tcp_client` pipeline directly from `options.servers` — unlike `mcp_openapi` or `mcp_schema_registry`, there is no upstream server, spec, or per-tool schema to author.
+The `mcp_kafka` client binding exposes a fixed set of Kafka broker operations as intrinsic MCP tools, connecting directly to the Kafka cluster named by `options.servers` — unlike `mcp_openapi` or `mcp_schema_registry`, there is no upstream server, spec, or per-tool schema to author.
 
 ```yaml {3}
 <!-- @include: ./.partials/client.yaml -->


### PR DESCRIPTION
## Description

Adds reference documentation for the `mcp_kafka` `client` binding, covering `options`, `routes`, and its full set of intrinsic MCP tools. This binding had no reference page at all in this repo (checked `support/2.x`, `develop`, and `main` — zero hits for `mcp_kafka`/`mcp-kafka`), so this is a new page set rather than an update to an existing one.

Tool coverage spans the config surface added across [aklivity/zilla#2228](https://github.com/aklivity/zilla/pull/2228) (`describe_configs`, `alter_configs`), [#2229](https://github.com/aklivity/zilla/pull/2229) (`list_topics`, `describe_topic`, `cluster_overview`), [#2230](https://github.com/aklivity/zilla/pull/2230) (`list_brokers`, `describe_cluster`), and [#2232](https://github.com/aklivity/zilla/pull/2232) (`list_consumer_groups`, `describe_consumer_group`, `reset_offsets`), plus the binding's original `produce`/`consume`/`create_topics`/`delete_topics` tools.

### New pages

- `src/reference/config/bindings/mcp-kafka/README.md`
- `src/reference/config/bindings/mcp-kafka/client.md`
- `src/reference/config/bindings/mcp-kafka/.partials/{client.yaml,options.md,routes.md,tools.md}`

`options.md` and `routes.md` follow the existing property-table conventions used by `mcp-openapi`/`mcp`. `tools.md` is a new structure — since `mcp_kafka`'s 14 tools are a fixed, intrinsic set (no `options.tools` override, no upstream spec to derive from, unlike `mcp_openapi`/`mcp_http`), there was no existing pattern in this repo for documenting a fixed tool catalog. Each tool gets its own `###` section with an arguments table and an `outputSchema` table (or a note when none is declared).

`options.authorization` (SASL credentials for the binding's own connection to the Kafka cluster) is documented against the current `binding-kafka` JSON schema definition (`mechanism`/`username`/`password` or `oauthbearer`/`token`). Note: this differs from the `options.sasl` name still shown on this branch's own `kafka` binding pages — `sasl` is `deprecated: true` in the current schema in favor of `authorization`, but no page anywhere in this repo yet documents `authorization`'s shape. Fixing that gap on the `kafka` binding itself is out of scope here; `mcp-kafka`'s docs describe the shape directly and self-contained rather than depending on an `authorization`-flavored shared partial that doesn't exist yet.

Also added a sidebar entry (`MCP-Kafka`, between `MCP` and `MCP-OpenAPI`) so the new pages are reachable.

### Verification

- `pnpm lint` — clean on the new files (pre-existing violations elsewhere are unrelated)
- `pnpm build` — clean, 321 pages rendered
- `link-checker` against the built `dist` — 0 errors, 0 warnings across 3300 local links
- Manually confirmed the `[create_topics]` cross-reference anchor against the actual rendered `id` (VuePress's slugifier hyphenates underscores, e.g. `create_topics` → `#create-topics`)
- Could not run `pnpm check-schema` meaningfully: `.check-schema/zilla-schema.json` has zero `mcp_kafka` occurrences, so it predates this binding entirely. Refreshing that snapshot needs a `docker run` against a Zilla build that ships `mcp_kafka`, which isn't available in this environment — flagging as a follow-up once this binding actually ships on the `2.x` line.

## Test plan

- [x] `pnpm lint` passes for the new files
- [x] `pnpm build` completes without errors
- [x] `link-checker` reports 0 errors against the built site
- [ ] Refresh `.check-schema/zilla-schema.json` from a Zilla build that ships `mcp_kafka` and run `pnpm check-schema` (follow-up, needs Docker)


---
_Generated by [Claude Code](https://claude.ai/code/session_018y5rq93rvSxyPB81tGLu9Q)_