### PR TITLE
docs(mcp): rename tools/prompts/resources condition fields to singular

### DIFF
--- a/src/reference/config/bindings/mcp/.partials/proxy.yaml
+++ b/src/reference/config/bindings/mcp/.partials/proxy.yaml
@@ -9,7 +9,7 @@ mcp_proxy:
     - exit: app1
       when:
         - toolkit: bluesky
-          tools:
+          tool:
             - post_*
     - exit: app2
       when:

--- a/src/reference/config/bindings/mcp/.partials/routes-client.md
+++ b/src/reference/config/bindings/mcp/.partials/routes-client.md
@@ -8,11 +8,11 @@ Conditional `mcp` specific routes, resolved per matched tool, prompt, or resourc
 routes:
   - exit: net_client
     when:
-      - tools:
+      - tool:
           - get_weather
   - exit: net_client
     when:
-      - tools:
+      - tool:
           - get_status
     guarded:
       my_jwt_guard:
@@ -39,23 +39,23 @@ routes:
 List of conditions (any match) to match this route.
 Read more: [When a route matches](/concepts/protocol/README.md#route-matches)
 
-#### when[].tools
+#### when[].tool
 
-> `array` of `string`
+> `string` or `array` of `string`
 
-Glob patterns of tool names to match, where `*` matches any sequence of characters. When omitted, all tools are admitted.
+Glob patterns of tool names to match, where `*` matches any sequence of characters. A bare string is shorthand for a single-element array. When omitted, all tools are admitted.
 
-#### when[].prompts
+#### when[].prompt
 
-> `array` of `string`
+> `string` or `array` of `string`
 
-Glob patterns of prompt names to match, where `*` matches any sequence of characters. When omitted, all prompts are admitted.
+Glob patterns of prompt names to match, where `*` matches any sequence of characters. A bare string is shorthand for a single-element array. When omitted, all prompts are admitted.
 
-#### when[].resources
+#### when[].resource
 
-> `array` of `string`
+> `string` or `array` of `string`
 
-Glob patterns of resource URIs to match, where `*` matches any sequence of characters. When omitted, all resources are admitted.
+Glob patterns of resource URIs to match, where `*` matches any sequence of characters. A bare string is shorthand for a single-element array. When omitted, all resources are admitted.
 
 #### routes[].exit
 

--- a/src/reference/config/bindings/mcp/.partials/routes-proxy.md
+++ b/src/reference/config/bindings/mcp/.partials/routes-proxy.md
@@ -30,23 +30,23 @@ Read more: [When a route matches](/concepts/protocol/README.md#route-matches)
 
 Toolkit name to match.
 
-#### when[].tools
+#### when[].tool
 
-> `array` of `string`
+> `string` or `array` of `string`
 
-Glob patterns of tool names to expose, where `*` matches any sequence of characters. Only tools whose name matches a pattern are routed. When omitted, all tools are admitted.
+Glob patterns of tool names to expose, where `*` matches any sequence of characters. Only tools whose name matches a pattern are routed. A bare string is shorthand for a single-element array. Presence of `tool` activates the tools capability for this condition; when none of `tool`, `prompt`, or `resource` are given, every capability is admitted.
 
-#### when[].prompts
+#### when[].prompt
 
-> `array` of `string`
+> `string` or `array` of `string`
 
-Glob patterns of prompt names to expose, where `*` matches any sequence of characters. Only prompts whose name matches a pattern are routed. When omitted, all prompts are admitted.
+Glob patterns of prompt names to expose, where `*` matches any sequence of characters. Only prompts whose name matches a pattern are routed. A bare string is shorthand for a single-element array. Presence of `prompt` activates the prompts capability for this condition.
 
-#### when[].resources
+#### when[].resource
 
-> `array` of `string`
+> `string` or `array` of `string`
 
-Glob patterns of resource URIs to expose, where `*` matches any sequence of characters. Only resources whose URI matches a pattern are routed. When omitted, all resources are admitted. Applies to both `resources/list` and `resources/templates/list`.
+Glob patterns of resource URIs to expose, where `*` matches any sequence of characters. Only resources whose URI matches a pattern are routed. A bare string is shorthand for a single-element array. Presence of `resource` activates the resources capability for this condition. Applies to both `resources/list` and `resources/templates/list`.
 
 #### routes[].with
 
@@ -77,7 +77,7 @@ routes:
   - exit: app1
     when:
       - toolkit: bluesky
-        tools:
+        tool:
           - post_*
     guarded:
       my_jwt_guard:


### PR DESCRIPTION
## Summary

Companion docs update for [aklivity/zilla#2253](https://github.com/aklivity/zilla/issues/2253) / [aklivity/zilla#2269](https://github.com/aklivity/zilla/pull/2269), rebased onto `support/2.x` (this line already carries the `mcp` reference docs).

- Renames the `mcp` binding's route condition fields `tools`/`prompts`/`resources` → `tool`/`prompt`/`resource` across both the `client`-kind and `proxy`-kind route docs (`routes-client.md`, `routes-proxy.md`) and the `proxy` YAML example
- Documents the new bare-string shorthand for a single-element array

## Test plan

- [x] `pnpm lint` (pre-existing failures only, none in the touched files)
- [ ] Visual check of `/reference/config/bindings/mcp/` pages once the corresponding Zilla release ships the renamed schema

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dn8Qvoir4yDrwyuXTucLS4)_