### PR TITLE
docs(mcp): use hyphenated type names for mcp-http/mcp-kafka/mcp-openapi

### DIFF
--- a/src/reference/config/bindings/mcp-http/.partials/options.md
+++ b/src/reference/config/bindings/mcp-http/.partials/options.md
@@ -2,7 +2,7 @@
 
 > `object`
 
-The `mcp_http` specific options.
+The `mcp-http` specific options.
 
 ```yaml
 options:

--- a/src/reference/config/bindings/mcp-http/.partials/proxy.yaml
+++ b/src/reference/config/bindings/mcp-http/.partials/proxy.yaml
@@ -1,5 +1,5 @@
 mcp_http_proxy:
-  type: mcp_http
+  type: mcp-http
   kind: proxy
   options:
     authorization:

--- a/src/reference/config/bindings/mcp-http/.partials/routes.md
+++ b/src/reference/config/bindings/mcp-http/.partials/routes.md
@@ -2,7 +2,7 @@
 
 > `array` of `object`
 
-Conditional `mcp_http` specific routes, resolving the upstream `http` request for a matched `tools/call` or `resources/read`.
+Conditional `mcp-http` specific routes, resolving the upstream `http` request for a matched `tools/call` or `resources/read`.
 
 ```yaml
 routes:

--- a/src/reference/config/bindings/mcp-http/README.md
+++ b/src/reference/config/bindings/mcp-http/README.md
@@ -9,13 +9,13 @@ tag:
 
 # mcp-http Binding
 
-The `proxy` kind `mcp_http` binding accepts `mcp` streams and produces `http` streams. It terminates `tools/list`, `resources/list`, and `resources/templates/list` from configuration, and expands `tools/call` and `resources/read` into upstream `http` requests.
+The `proxy` kind `mcp-http` binding accepts `mcp` streams and produces `http` streams. It terminates `tools/list`, `resources/list`, and `resources/templates/list` from configuration, and expands `tools/call` and `resources/read` into upstream `http` requests.
 
 ## proxy
 
 > [Full config](./proxy.md)
 
-Behave as an `mcp_http` `proxy`.
+Behave as an `mcp-http` `proxy`.
 
 ```yaml {3}
 <!-- @include: ./.partials/proxy.yaml -->

--- a/src/reference/config/bindings/mcp-http/proxy.md
+++ b/src/reference/config/bindings/mcp-http/proxy.md
@@ -4,7 +4,7 @@ shortTitle: proxy
 
 # mcp-http proxy
 
-The `mcp_http` proxy binding accepts `mcp` streams and produces `http` streams, terminating `tools/list`, `resources/list`, and `resources/templates/list` from configuration, and expanding `tools/call` and `resources/read` into upstream `http` requests.
+The `mcp-http` proxy binding accepts `mcp` streams and produces `http` streams, terminating `tools/list`, `resources/list`, and `resources/templates/list` from configuration, and expanding `tools/call` and `resources/read` into upstream `http` requests.
 
 ```yaml {3}
 <!-- @include: ./.partials/proxy.yaml -->

--- a/src/reference/config/bindings/mcp-kafka/.partials/client.yaml
+++ b/src/reference/config/bindings/mcp-kafka/.partials/client.yaml
@@ -1,5 +1,5 @@
 mcp_kafka_client:
-  type: mcp_kafka
+  type: mcp-kafka
   kind: client
   options:
     servers:

--- a/src/reference/config/bindings/mcp-kafka/.partials/routes.md
+++ b/src/reference/config/bindings/mcp-kafka/.partials/routes.md
@@ -2,7 +2,7 @@
 
 > `array` of `object`
 
-Conditional `mcp_kafka` specific routes, matching by tool name and, for `produce` and `consume`, by topic. At least one route is required. Routes are evaluated in order; the first matching route wins.
+Conditional `mcp-kafka` specific routes, matching by tool name and, for `produce` and `consume`, by topic. At least one route is required. Routes are evaluated in order; the first matching route wins.
 
 ```yaml
 routes:

--- a/src/reference/config/bindings/mcp-kafka/.partials/tools.md
+++ b/src/reference/config/bindings/mcp-kafka/.partials/tools.md
@@ -1,4 +1,4 @@
-The `mcp_kafka` client exposes a fixed set of intrinsic tools — there is no `options.tools` to author, and no upstream server or spec to derive them from. Each tool's `inputSchema` validates `tools/call` `arguments` before Zilla dispatches the matching Kafka request; a tool with no declared `outputSchema` still returns a result, either as `structuredContent` or as `content` text only.
+The `mcp-kafka` client exposes a fixed set of intrinsic tools — there is no `options.tools` to author, and no upstream server or spec to derive them from. Each tool's `inputSchema` validates `tools/call` `arguments` before Zilla dispatches the matching Kafka request; a tool with no declared `outputSchema` still returns a result, either as `structuredContent` or as `content` text only.
 
 ### produce
 

--- a/src/reference/config/bindings/mcp-kafka/README.md
+++ b/src/reference/config/bindings/mcp-kafka/README.md
@@ -9,13 +9,13 @@ tag:
 
 # mcp-kafka Binding
 
-The `client` kind `mcp_kafka` binding exposes a fixed set of Kafka broker operations — producing and consuming records, managing topics and their configs, and inspecting brokers and consumer groups — as intrinsic MCP tools, connecting directly to the Kafka cluster named by `options.servers`, with no upstream MCP or REST server and no per-tool schema authoring.
+The `client` kind `mcp-kafka` binding exposes a fixed set of Kafka broker operations — producing and consuming records, managing topics and their configs, and inspecting brokers and consumer groups — as intrinsic MCP tools, connecting directly to the Kafka cluster named by `options.servers`, with no upstream MCP or REST server and no per-tool schema authoring.
 
 ## client
 
 > [Full config](./client.md)
 
-Behave as an `mcp_kafka` `client`.
+Behave as an `mcp-kafka` `client`.
 
 ```yaml {3}
 <!-- @include: ./.partials/client.yaml -->

--- a/src/reference/config/bindings/mcp-kafka/client.md
+++ b/src/reference/config/bindings/mcp-kafka/client.md
@@ -4,7 +4,7 @@ shortTitle: client
 
 # mcp-kafka client
 
-The `mcp_kafka` client binding exposes a fixed set of Kafka broker operations as intrinsic MCP tools, connecting directly to the Kafka cluster named by `options.servers` — unlike `mcp_openapi` or `mcp_schema_registry`, there is no upstream server, spec, or per-tool schema to author.
+The `mcp-kafka` client binding exposes a fixed set of Kafka broker operations as intrinsic MCP tools, connecting directly to the Kafka cluster named by `options.servers` — unlike `mcp-openapi` or `mcp-schema-registry`, there is no upstream server, spec, or per-tool schema to author.
 
 ```yaml {3}
 <!-- @include: ./.partials/client.yaml -->

--- a/src/reference/config/bindings/mcp-openapi/.partials/client.yaml
+++ b/src/reference/config/bindings/mcp-openapi/.partials/client.yaml
@@ -1,5 +1,5 @@
 mcp_openapi_client:
-  type: mcp_openapi
+  type: mcp-openapi
   kind: client
   options:
     specs:

--- a/src/reference/config/bindings/mcp-openapi/.partials/options.md
+++ b/src/reference/config/bindings/mcp-openapi/.partials/options.md
@@ -2,7 +2,7 @@
 
 > `object`
 
-The `mcp_openapi` specific options.
+The `mcp-openapi` specific options.
 
 ```yaml
 options:

--- a/src/reference/config/bindings/mcp-openapi/.partials/routes.md
+++ b/src/reference/config/bindings/mcp-openapi/.partials/routes.md
@@ -2,7 +2,7 @@
 
 > `array` of `object`
 
-Conditional `mcp_openapi` specific routes, compiling matched OpenAPI operations into the generated `mcp_http` proxy as MCP tools or resources. At least one route is required.
+Conditional `mcp-openapi` specific routes, compiling matched OpenAPI operations into the generated `mcp-http` proxy as MCP tools or resources. At least one route is required.
 
 A route either names a single operation explicitly, or bulk-selects many operations at once:
 
@@ -90,7 +90,7 @@ routes:
 
 > `object`
 
-Resolves the OpenAPI operation or operations compiled into the generated `mcp_http` proxy for this route.
+Resolves the OpenAPI operation or operations compiled into the generated `mcp-http` proxy for this route.
 
 ```yaml
 with:

--- a/src/reference/config/bindings/mcp-openapi/README.md
+++ b/src/reference/config/bindings/mcp-openapi/README.md
@@ -9,13 +9,13 @@ tag:
 
 # mcp-openapi Binding
 
-The `client` kind `mcp_openapi` binding reads OpenAPI specifications from a catalog and compiles routed operations — named individually or bulk-selected by spec, tag, or glob pattern — into a generated `mcp_http` proxy, exposing them as MCP tools and resources with a single spec parse and no protocol-specific code.
+The `client` kind `mcp-openapi` binding reads OpenAPI specifications from a catalog and compiles routed operations — named individually or bulk-selected by spec, tag, or glob pattern — into a generated `mcp-http` proxy, exposing them as MCP tools and resources with a single spec parse and no protocol-specific code.
 
 ## client
 
 > [Full config](./client.md)
 
-Behave as an `mcp_openapi` `client`.
+Behave as an `mcp-openapi` `client`.
 
 ```yaml {3}
 <!-- @include: ./.partials/client.yaml -->

--- a/src/reference/config/bindings/mcp-openapi/client.md
+++ b/src/reference/config/bindings/mcp-openapi/client.md
@@ -4,7 +4,7 @@ shortTitle: client
 
 # mcp-openapi client
 
-The `mcp_openapi` client binding parses OpenAPI specifications from a catalog and compiles routed operations — named individually or bulk-selected by spec, tag, or glob pattern — into a generated composite `mcp_http` proxy binding, exposing them as MCP tools and resources with a single spec parse.
+The `mcp-openapi` client binding parses OpenAPI specifications from a catalog and compiles routed operations — named individually or bulk-selected by spec, tag, or glob pattern — into a generated composite `mcp-http` proxy binding, exposing them as MCP tools and resources with a single spec parse.
 
 ```yaml {3}
 <!-- @include: ./.partials/client.yaml -->


### PR DESCRIPTION
## Description

Companion doc update for [aklivity/zilla's mcp-* binding type rename](https://github.com/aklivity/zilla/pull/new/claude/mcp-binding-type-naming-hom0vg) (`mcp_http`/`mcp_kafka`/`mcp_openapi`/`mcp_schema_registry` → `mcp-http`/`mcp-kafka`/`mcp-openapi`/`mcp-schema-registry`), matching the hyphen-separated convention used by every other composite binding type (`grpc-kafka`, `http-kafka`, `mqtt-kafka`, etc.).

Updates prose and the `.partials/*.yaml` `type:` fields across the three existing doc page sets:
- `src/reference/config/bindings/mcp-http/`
- `src/reference/config/bindings/mcp-kafka/`
- `src/reference/config/bindings/mcp-openapi/`

(`mcp-schema-registry` has no doc page yet, so there's nothing to update for it here.)

Binding-name labels (e.g. `mcp_http_proxy:`, `mcp_kafka_client:`) are left underscored — that's a separate, unrelated naming convention for binding *names* used throughout the docs (e.g. the already-hyphenated `http-kafka` binding's own example uses `http_kafka_proxy:`), distinct from the hyphenated `type:` discriminator.

Targeting `support/2.x` rather than `develop` since that's the branch currently carrying these `mcp-*` reference pages.

## Verification

- `pnpm lint` — clean on the touched files
- Residual grep sweep confirms only the (expected, unrelated) binding-name labels remain


---
_Generated by [Claude Code](https://claude.ai/code/session_01BC3YGEYzbzPq1oi3GtbrV6)_