### PR TITLE
docs(mcp): add mcp-kafka-connect and mcp-schema-registry binding reference

### DIFF
--- a/src/.vuepress/sidebar/en.ts
+++ b/src/.vuepress/sidebar/en.ts
@@ -132,9 +132,23 @@ export const enSidebar = sidebar({
           children: "structure",
         },
         {
+          text: "MCP-Kafka-Connect",
+          icon: "fa-solid fa-robot",
+          prefix: "mcp-kafka-connect",
+          collapsible: true,
+          children: "structure",
+        },
+        {
           text: "MCP-OpenAPI",
           icon: "fa-solid fa-robot",
           prefix: "mcp-openapi",
+          collapsible: true,
+          children: "structure",
+        },
+        {
+          text: "MCP-Schema-Registry",
+          icon: "fa-solid fa-robot",
+          prefix: "mcp-schema-registry",
           collapsible: true,
           children: "structure",
         },

--- a/src/reference/config/bindings/mcp-kafka-connect/.partials/client.yaml
+++ b/src/reference/config/bindings/mcp-kafka-connect/.partials/client.yaml
@@ -1,0 +1,22 @@
+mcp_kafka_connect_client:
+  type: mcp-kafka-connect
+  kind: client
+  options:
+    server: http://kafka-connect.examples.dev:8083
+  routes:
+    - when:
+        - tool: create_connector
+        - tool: delete_connector
+        - tool: update_connector_config
+        - tool: restart_connector
+        - tool: pause_connector
+        - tool: resume_connector
+        - tool: stop_connector
+        - tool: restart_connector_task
+        - tool: alter_connector_offsets
+        - tool: reset_connector_offsets
+      guarded:
+        my_guard:
+          - kafka-connect:admin
+    - when:
+        - tool: "*"

--- a/src/reference/config/bindings/mcp-kafka-connect/.partials/options.md
+++ b/src/reference/config/bindings/mcp-kafka-connect/.partials/options.md
@@ -1,0 +1,16 @@
+### options\*
+
+> `object`
+
+The `client` specific options.
+
+```yaml
+options:
+  server: http://kafka-connect.examples.dev:8083
+```
+
+#### options.server\*
+
+> `string`
+
+Base URL of the Kafka Connect REST API this binding proxies to.

--- a/src/reference/config/bindings/mcp-kafka-connect/.partials/routes.md
+++ b/src/reference/config/bindings/mcp-kafka-connect/.partials/routes.md
@@ -1,0 +1,50 @@
+### routes\*
+
+> `array` of `object`
+
+Conditional `mcp-kafka-connect` specific routes, matching by tool name or glob pattern. At least one route is required. Routes are evaluated in order; the first matching route wins.
+
+```yaml
+routes:
+  - when:
+      - tool: delete_connector
+    guarded:
+      my_guard:
+        - kafka-connect:admin
+  - when:
+      - tool: "*"
+```
+
+#### routes[].when\*
+
+> `array` of `object`
+
+List of conditions (any match) restricting this route to particular tools. Required.
+
+```yaml
+routes:
+  - when:
+      - tool: create_connector
+      - tool: delete_connector
+```
+
+#### when[].tool\*
+
+> `string` or `array` of `string`
+
+Tool name matched by `tools/call`, or a `*` glob pattern matching many tool names in bulk (such as `list_*`). Required.
+
+#### routes[].guarded
+
+> `object` as map of named `array` of `string`
+
+Roles required by the named guard for a `tools/call` against this route. Roles for the same guard are unioned into one entry; roles naming a different guard add a separate entry that must also authorize.
+
+```yaml
+routes:
+  - when:
+      - tool: delete_connector
+    guarded:
+      my_guard:
+        - kafka-connect:admin
+```

--- a/src/reference/config/bindings/mcp-kafka-connect/.partials/tools.md
+++ b/src/reference/config/bindings/mcp-kafka-connect/.partials/tools.md
@@ -1,4 +1,4 @@
-The `mcp-kafka-connect` client exposes a fixed set of intrinsic tools, derived from a bundled Kafka Connect REST API specification — there is no `options.tools` to author, and no upstream server or spec to select. Each tool's `inputSchema` validates `tools/call` `arguments` before Zilla dispatches the matching request to `options.server`; a tool with no fixed `outputSchema` still returns a result, either as `structuredContent` mirroring the raw upstream JSON response or as `content` text only.
+The `mcp-kafka-connect` client exposes a fixed set of intrinsic tools, derived from a bundled Kafka Connect REST API specification — there is no `options.tools` to author, and no upstream server or spec to select. Each tool's `inputSchema` validates `tools/call` `arguments` before Zilla dispatches the matching request to `options.server`. Every tool's `structuredContent` carries the upstream JSON response — validated and pruned to a declared `outputSchema` where one exists, or the raw body unchanged where none is declared — and `content` carries the tool's `summary` text, which may itself interpolate fields out of that same response via `${result.x}`.
 
 ### list_connectors
 
@@ -8,7 +8,7 @@ Lists the names of every connector on the worker.
 
 No arguments.
 
-No `outputSchema` is declared; the result is a `content` text summary only.
+No fixed `outputSchema` is declared; the result's `structuredContent` mirrors the raw upstream JSON response — an array of connector names — with no fixed property list.
 
 ### create_connector
 
@@ -21,7 +21,7 @@ Creates a new connector.
 | `name` | `string` | Yes | Connector name. |
 | `config` | `object` as map of named `string` | Yes | Connector configuration properties. |
 
-No `outputSchema` is declared; the result is a `content` text summary only.
+No fixed `outputSchema` is declared; the result's `structuredContent` mirrors the raw upstream JSON response, with no fixed property list. The summary interpolates `${result.name}`.
 
 ### describe_connector
 
@@ -33,7 +33,7 @@ Reads one connector's configuration and task list by name.
 | --- | --- | --- | --- |
 | `connector` | `string` | Yes | Connector to describe. |
 
-No `outputSchema` is declared; the result is a `content` text summary only.
+No fixed `outputSchema` is declared; the result's `structuredContent` mirrors the raw upstream JSON response, with no fixed property list. The summary interpolates `${result.name}`.
 
 ### delete_connector
 
@@ -45,7 +45,7 @@ Deletes a connector.
 | --- | --- | --- | --- |
 | `connector` | `string` | Yes | Connector to delete. |
 
-No `outputSchema` is declared; the result is a `content` text summary only.
+No fixed `outputSchema` is declared; the result's `structuredContent` mirrors the raw upstream JSON response, with no fixed property list. The summary interpolates `${result.name}`.
 
 ### describe_connector_config
 
@@ -71,7 +71,7 @@ Creates or updates a connector by setting its full configuration.
 | `connector.class` | `string` | Yes | Connector class to instantiate. |
 | `tasks.max` | `string` | Yes | Maximum number of tasks to run. |
 
-No `outputSchema` is declared; the result is a `content` text summary only.
+No fixed `outputSchema` is declared; the result's `structuredContent` mirrors the raw upstream JSON response, with no fixed property list. The summary interpolates `${result.name}`.
 
 ### validate_connector_config
 
@@ -85,7 +85,7 @@ Validates a connector configuration against a plugin's configuration definition,
 | `connector.class` | `string` | Yes | Connector class to validate. |
 | `tasks.max` | `string` | Yes | Maximum number of tasks to validate. |
 
-No `outputSchema` is declared; the result is a `content` text summary only, such as `Validated connector config with 0 errors`.
+No fixed `outputSchema` is declared; the result's `structuredContent` mirrors the raw upstream JSON response, with no fixed property list. The summary interpolates `${result.error_count}`, such as `Validated connector config with 0 errors`.
 
 ### describe_connector_status
 
@@ -97,7 +97,7 @@ Reads a connector's current state and the state of each of its tasks.
 | --- | --- | --- | --- |
 | `connector` | `string` | Yes | Connector to check the status of. |
 
-No `outputSchema` is declared; the result is a `content` text summary only, such as `Connector my-connector is RUNNING`.
+No fixed `outputSchema` is declared; the result's `structuredContent` mirrors the raw upstream JSON response, with no fixed property list. The summary interpolates `${result.name}` and `${result.connector.state}`, such as `Connector my-connector is RUNNING`.
 
 ### restart_connector
 
@@ -109,7 +109,7 @@ Restarts a connector.
 | --- | --- | --- | --- |
 | `connector` | `string` | Yes | Connector to restart. |
 
-No `outputSchema` is declared; the result is a `content` text summary only.
+No fixed `outputSchema` is declared; the result's `structuredContent` mirrors the raw upstream JSON response, with no fixed property list. The summary interpolates `${result.name}`.
 
 ### pause_connector
 
@@ -121,7 +121,7 @@ Pauses a connector and all of its tasks.
 | --- | --- | --- | --- |
 | `connector` | `string` | Yes | Connector to pause. |
 
-No `outputSchema` is declared; the result is a `content` text summary only.
+No fixed `outputSchema` is declared; the result's `structuredContent` mirrors the raw upstream JSON response, with no fixed property list. The summary interpolates `${result.name}`.
 
 ### resume_connector
 
@@ -133,7 +133,7 @@ Resumes a paused connector and all of its tasks.
 | --- | --- | --- | --- |
 | `connector` | `string` | Yes | Connector to resume. |
 
-No `outputSchema` is declared; the result is a `content` text summary only.
+No fixed `outputSchema` is declared; the result's `structuredContent` mirrors the raw upstream JSON response, with no fixed property list. The summary interpolates `${result.name}`.
 
 ### stop_connector
 
@@ -145,7 +145,7 @@ Stops a connector and shuts down all of its tasks, without deleting the connecto
 | --- | --- | --- | --- |
 | `connector` | `string` | Yes | Connector to stop. |
 
-No `outputSchema` is declared; the result is a `content` text summary only.
+No fixed `outputSchema` is declared; the result's `structuredContent` mirrors the raw upstream JSON response, with no fixed property list. The summary interpolates `${result.name}`.
 
 ### list_connector_tasks
 
@@ -157,7 +157,7 @@ Lists every task belonging to a connector.
 | --- | --- | --- | --- |
 | `connector` | `string` | Yes | Connector whose tasks to list. |
 
-No `outputSchema` is declared; the result is a `content` text summary only.
+No fixed `outputSchema` is declared; the result's `structuredContent` mirrors the raw upstream JSON response, with no fixed property list.
 
 ### restart_connector_task
 
@@ -197,7 +197,7 @@ Overwrites a connector's source or sink offsets. The connector must be stopped f
 | `offsets[].partition` | `object` | Yes | Source partition or sink topic-partition identifying the offset. |
 | `offsets[].offset` | `object` | Yes | New offset value for the identified partition. |
 
-No `outputSchema` is declared; the result is a `content` text summary only, interpolated from the upstream response, such as `${result.message}`.
+No fixed `outputSchema` is declared; the result's `structuredContent` mirrors the raw upstream JSON response, with no fixed property list. The summary interpolates `${result.message}`.
 
 ### reset_connector_offsets
 
@@ -209,7 +209,7 @@ Resets a connector's source or sink offsets to their initial state. The connecto
 | --- | --- | --- | --- |
 | `connector` | `string` | Yes | Connector whose offsets to reset. |
 
-No `outputSchema` is declared; the result is a `content` text summary only, interpolated from the upstream response, such as `${result.message}`.
+No fixed `outputSchema` is declared; the result's `structuredContent` mirrors the raw upstream JSON response, with no fixed property list. The summary interpolates `${result.message}`.
 
 ### list_connector_plugins
 
@@ -219,4 +219,4 @@ Lists every connector plugin installed on the worker.
 
 No arguments.
 
-No `outputSchema` is declared; the result is a `content` text summary only.
+No fixed `outputSchema` is declared; the result's `structuredContent` mirrors the raw upstream JSON response — an array of installed plugins — with no fixed property list.

--- a/src/reference/config/bindings/mcp-kafka-connect/.partials/tools.md
+++ b/src/reference/config/bindings/mcp-kafka-connect/.partials/tools.md
@@ -1,0 +1,222 @@
+The `mcp-kafka-connect` client exposes a fixed set of intrinsic tools, derived from a bundled Kafka Connect REST API specification — there is no `options.tools` to author, and no upstream server or spec to select. Each tool's `inputSchema` validates `tools/call` `arguments` before Zilla dispatches the matching request to `options.server`; a tool with no fixed `outputSchema` still returns a result, either as `structuredContent` mirroring the raw upstream JSON response or as `content` text only.
+
+### list_connectors
+
+> Read-only, idempotent
+
+Lists the names of every connector on the worker.
+
+No arguments.
+
+No `outputSchema` is declared; the result is a `content` text summary only.
+
+### create_connector
+
+> Not destructive, not idempotent
+
+Creates a new connector.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `string` | Yes | Connector name. |
+| `config` | `object` as map of named `string` | Yes | Connector configuration properties. |
+
+No `outputSchema` is declared; the result is a `content` text summary only.
+
+### describe_connector
+
+> Read-only, idempotent
+
+Reads one connector's configuration and task list by name.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `connector` | `string` | Yes | Connector to describe. |
+
+No `outputSchema` is declared; the result is a `content` text summary only.
+
+### delete_connector
+
+> Destructive, idempotent
+
+Deletes a connector.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `connector` | `string` | Yes | Connector to delete. |
+
+No `outputSchema` is declared; the result is a `content` text summary only.
+
+### describe_connector_config
+
+> Read-only, idempotent
+
+Reads the effective configuration of a connector.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `connector` | `string` | Yes | Connector to read the configuration of. |
+
+No fixed `outputSchema` is declared; the result's `structuredContent` mirrors the raw upstream JSON response, with no fixed property list.
+
+### update_connector_config
+
+> Not destructive, idempotent
+
+Creates or updates a connector by setting its full configuration.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `connector` | `string` | Yes | Connector to configure. |
+| `connector.class` | `string` | Yes | Connector class to instantiate. |
+| `tasks.max` | `string` | Yes | Maximum number of tasks to run. |
+
+No `outputSchema` is declared; the result is a `content` text summary only.
+
+### validate_connector_config
+
+> Read-only, idempotent
+
+Validates a connector configuration against a plugin's configuration definition, without creating or updating any connector.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `pluginName` | `string` | Yes | Connector plugin to validate against. |
+| `connector.class` | `string` | Yes | Connector class to validate. |
+| `tasks.max` | `string` | Yes | Maximum number of tasks to validate. |
+
+No `outputSchema` is declared; the result is a `content` text summary only, such as `Validated connector config with 0 errors`.
+
+### describe_connector_status
+
+> Read-only, idempotent
+
+Reads a connector's current state and the state of each of its tasks.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `connector` | `string` | Yes | Connector to check the status of. |
+
+No `outputSchema` is declared; the result is a `content` text summary only, such as `Connector my-connector is RUNNING`.
+
+### restart_connector
+
+> Not destructive, not idempotent
+
+Restarts a connector.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `connector` | `string` | Yes | Connector to restart. |
+
+No `outputSchema` is declared; the result is a `content` text summary only.
+
+### pause_connector
+
+> Not destructive, idempotent
+
+Pauses a connector and all of its tasks.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `connector` | `string` | Yes | Connector to pause. |
+
+No `outputSchema` is declared; the result is a `content` text summary only.
+
+### resume_connector
+
+> Not destructive, idempotent
+
+Resumes a paused connector and all of its tasks.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `connector` | `string` | Yes | Connector to resume. |
+
+No `outputSchema` is declared; the result is a `content` text summary only.
+
+### stop_connector
+
+> Not destructive, idempotent
+
+Stops a connector and shuts down all of its tasks, without deleting the connector.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `connector` | `string` | Yes | Connector to stop. |
+
+No `outputSchema` is declared; the result is a `content` text summary only.
+
+### list_connector_tasks
+
+> Read-only, idempotent
+
+Lists every task belonging to a connector.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `connector` | `string` | Yes | Connector whose tasks to list. |
+
+No `outputSchema` is declared; the result is a `content` text summary only.
+
+### restart_connector_task
+
+> Not destructive, not idempotent
+
+Restarts a single task belonging to a connector.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `connector` | `string` | Yes | Connector owning the task. |
+| `task` | `integer` | Yes | Task id to restart. |
+
+No fixed `outputSchema` is declared; the result's `structuredContent` mirrors the raw upstream JSON response, with no fixed property list.
+
+### describe_connector_offsets
+
+> Read-only, idempotent
+
+Reads a connector's current source or sink offsets.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `connector` | `string` | Yes | Connector whose offsets to read. |
+
+No fixed `outputSchema` is declared; the result's `structuredContent` mirrors the raw upstream JSON response, with no fixed property list.
+
+### alter_connector_offsets
+
+> Destructive, idempotent
+
+Overwrites a connector's source or sink offsets. The connector must be stopped first.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `connector` | `string` | Yes | Connector whose offsets to alter. |
+| `offsets` | `array` of `object` | Yes | Offsets to write. |
+| `offsets[].partition` | `object` | Yes | Source partition or sink topic-partition identifying the offset. |
+| `offsets[].offset` | `object` | Yes | New offset value for the identified partition. |
+
+No `outputSchema` is declared; the result is a `content` text summary only, interpolated from the upstream response, such as `${result.message}`.
+
+### reset_connector_offsets
+
+> Destructive, idempotent
+
+Resets a connector's source or sink offsets to their initial state. The connector must be stopped first.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `connector` | `string` | Yes | Connector whose offsets to reset. |
+
+No `outputSchema` is declared; the result is a `content` text summary only, interpolated from the upstream response, such as `${result.message}`.
+
+### list_connector_plugins
+
+> Read-only, idempotent
+
+Lists every connector plugin installed on the worker.
+
+No arguments.
+
+No `outputSchema` is declared; the result is a `content` text summary only.

--- a/src/reference/config/bindings/mcp-kafka-connect/README.md
+++ b/src/reference/config/bindings/mcp-kafka-connect/README.md
@@ -1,0 +1,22 @@
+---
+shortTitle: mcp-kafka-connect
+category:
+  - Binding
+tag:
+  - mcp-kafka-connect
+  - client
+---
+
+# mcp-kafka-connect Binding
+
+The `client` kind `mcp-kafka-connect` binding exposes the Kafka Connect REST API — connectors, tasks, offsets, and plugins — as a fixed set of intrinsic MCP tools, connecting directly to the Kafka Connect worker named by `options.server`, with no upstream MCP server, OpenAPI spec, or per-tool schema authoring.
+
+## client
+
+> [Full config](./client.md)
+
+Behave as an `mcp-kafka-connect` `client`.
+
+```yaml {3}
+<!-- @include: ./.partials/client.yaml -->
+```

--- a/src/reference/config/bindings/mcp-kafka-connect/client.md
+++ b/src/reference/config/bindings/mcp-kafka-connect/client.md
@@ -1,0 +1,21 @@
+---
+shortTitle: client
+---
+
+# mcp-kafka-connect client
+
+The `mcp-kafka-connect` client binding exposes the Kafka Connect REST API as a fixed set of intrinsic MCP tools, connecting directly to the Kafka Connect worker named by `options.server` — unlike [`mcp-openapi`](../mcp-openapi/client.md), there is no upstream spec or per-tool schema to author. [`mcp-kafka`](../mcp-kafka/client.md) and [`mcp-schema-registry`](../mcp-schema-registry/client.md) follow the same fixed-tool pattern for the Kafka broker and schema registry APIs.
+
+```yaml {3}
+<!-- @include: ./.partials/client.yaml -->
+```
+
+## Configuration (\* required)
+
+<!-- @include: ./.partials/options.md -->
+<!-- @include: ./.partials/routes.md -->
+<!-- @include: ../.partials/telemetry.md -->
+
+## Tools
+
+<!-- @include: ./.partials/tools.md -->

--- a/src/reference/config/bindings/mcp-kafka/client.md
+++ b/src/reference/config/bindings/mcp-kafka/client.md
@@ -4,7 +4,7 @@ shortTitle: client
 
 # mcp-kafka client
 
-The `mcp-kafka` client binding exposes a fixed set of Kafka broker operations as intrinsic MCP tools, connecting directly to the Kafka cluster named by `options.servers` — unlike `mcp-openapi` or `mcp-schema-registry`, there is no upstream server, spec, or per-tool schema to author.
+The `mcp-kafka` client binding exposes a fixed set of Kafka broker operations as intrinsic MCP tools, connecting directly to the Kafka cluster named by `options.servers` — unlike [`mcp-openapi`](../mcp-openapi/client.md), there is no upstream server, spec, or per-tool schema to author. [`mcp-kafka-connect`](../mcp-kafka-connect/client.md) and [`mcp-schema-registry`](../mcp-schema-registry/client.md) follow the same fixed-tool pattern for the Kafka Connect and schema registry REST APIs.
 
 ```yaml {3}
 <!-- @include: ./.partials/client.yaml -->

--- a/src/reference/config/bindings/mcp-schema-registry/.partials/client.yaml
+++ b/src/reference/config/bindings/mcp-schema-registry/.partials/client.yaml
@@ -1,0 +1,13 @@
+mcp_schema_registry_client:
+  type: mcp-schema-registry
+  kind: client
+  options:
+    server: http://karapace-registry.examples.dev:8081
+  routes:
+    - when:
+        - tool: register_schema
+      guarded:
+        my_guard:
+          - kafka-sr:write
+    - when:
+        - tool: "*"

--- a/src/reference/config/bindings/mcp-schema-registry/.partials/options.md
+++ b/src/reference/config/bindings/mcp-schema-registry/.partials/options.md
@@ -1,0 +1,16 @@
+### options\*
+
+> `object`
+
+The `client` specific options.
+
+```yaml
+options:
+  server: http://karapace-registry.examples.dev:8081
+```
+
+#### options.server\*
+
+> `string`
+
+Base URL of the schema registry this binding proxies to.

--- a/src/reference/config/bindings/mcp-schema-registry/.partials/routes.md
+++ b/src/reference/config/bindings/mcp-schema-registry/.partials/routes.md
@@ -1,0 +1,50 @@
+### routes\*
+
+> `array` of `object`
+
+Conditional `mcp-schema-registry` specific routes, matching by tool name or glob pattern. At least one route is required. Routes are evaluated in order; the first matching route wins.
+
+```yaml
+routes:
+  - when:
+      - tool: register_schema
+    guarded:
+      my_guard:
+        - kafka-sr:write
+  - when:
+      - tool: "*"
+```
+
+#### routes[].when\*
+
+> `array` of `object`
+
+List of conditions (any match) restricting this route to particular tools. Required.
+
+```yaml
+routes:
+  - when:
+      - tool: register_schema
+      - tool: set_compatibility
+```
+
+#### when[].tool\*
+
+> `string` or `array` of `string`
+
+Tool name matched by `tools/call`, or a `*` glob pattern matching many tool names in bulk (such as `list_*`). Required.
+
+#### routes[].guarded
+
+> `object` as map of named `array` of `string`
+
+Roles required by the named guard for a `tools/call` against this route. Roles for the same guard are unioned into one entry; roles naming a different guard add a separate entry that must also authorize.
+
+```yaml
+routes:
+  - when:
+      - tool: register_schema
+    guarded:
+      my_guard:
+        - kafka-sr:write
+```

--- a/src/reference/config/bindings/mcp-schema-registry/.partials/tools.md
+++ b/src/reference/config/bindings/mcp-schema-registry/.partials/tools.md
@@ -1,10 +1,12 @@
-The `mcp-schema-registry` client exposes a fixed set of intrinsic tools, derived from a bundled schema registry API specification — there is no `options.tools` to author, and no upstream server or spec to select. Each tool's `inputSchema` validates `tools/call` `arguments` before Zilla dispatches the matching request to `options.server`. None of these tools declare a fixed `outputSchema`; each returns a `content` text summary, though the summary may interpolate fields of the raw upstream JSON response, such as `${result.id}`.
+The `mcp-schema-registry` client exposes a fixed set of intrinsic tools, derived from a bundled schema registry API specification — there is no `options.tools` to author, and no upstream server or spec to select. Each tool's `inputSchema` validates `tools/call` `arguments` before Zilla dispatches the matching request to `options.server`. None of these tools declare a fixed `outputSchema`, so each tool's `structuredContent` mirrors the raw upstream JSON response with no fixed property list, and its `summary` text may interpolate fields out of that same response, such as `${result.id}`.
 
 ### list_subjects
 
 Lists every subject registered in the schema registry.
 
 No arguments.
+
+The result's `structuredContent` mirrors the raw upstream JSON response — an array of subject names.
 
 ### describe_subject
 
@@ -13,6 +15,8 @@ Lists the schema version numbers registered for a subject.
 | Argument | Type | Required | Description |
 | --- | --- | --- | --- |
 | `subject` | `string` | Yes | Subject to list versions for. |
+
+The result's `structuredContent` mirrors the raw upstream JSON response — an array of version numbers.
 
 ### register_schema
 
@@ -24,6 +28,8 @@ Registers a new schema version under a subject.
 | `schema` | `string` | Yes | Schema document to register. |
 | `schemaType` | `string` | No | Schema format, such as `AVRO`, `JSON`, or `PROTOBUF`. Defaults to `AVRO` when omitted. |
 
+The summary interpolates `${result.id}`, such as `Registered schema with id 1`.
+
 ### get_schema
 
 Retrieves a specific registered schema version for a subject.
@@ -32,6 +38,8 @@ Retrieves a specific registered schema version for a subject.
 | --- | --- | --- | --- |
 | `subject` | `string` | Yes | Subject to read from. |
 | `version` | `string` | Yes | Schema version number, or `latest`. |
+
+The summary interpolates `${result.id}` and `${result.version}`, such as `Retrieved schema id 1, version 1`.
 
 ### delete_schema_version
 
@@ -50,6 +58,8 @@ Deletes a subject and every schema version registered under it.
 | --- | --- | --- | --- |
 | `subject` | `string` | Yes | Subject to delete. |
 
+The result's `structuredContent` mirrors the raw upstream JSON response — an array of the deleted subject's version numbers.
+
 ### check_compatibility
 
 Checks whether a schema is compatible with a specific already-registered version of a subject.
@@ -61,6 +71,8 @@ Checks whether a schema is compatible with a specific already-registered version
 | `schema` | `string` | Yes | Schema document to check. |
 | `schemaType` | `string` | No | Schema format, such as `AVRO`, `JSON`, or `PROTOBUF`. Defaults to `AVRO` when omitted. |
 
+The summary interpolates `${result.is_compatible}`, such as `Compatibility check result: true`.
+
 ### get_compatibility
 
 Reads the compatibility level configured for a subject.
@@ -68,6 +80,8 @@ Reads the compatibility level configured for a subject.
 | Argument | Type | Required | Description |
 | --- | --- | --- | --- |
 | `subject` | `string` | Yes | Subject to read the compatibility level of. |
+
+The summary interpolates `${result.compatibilityLevel}`, such as `Compatibility level is FULL`.
 
 ### set_compatibility
 
@@ -77,3 +91,5 @@ Sets the compatibility level for a subject.
 | --- | --- | --- | --- |
 | `subject` | `string` | Yes | Subject to set the compatibility level of. |
 | `compatibility` | `string` | Yes | Compatibility level, such as `BACKWARD`, `FORWARD`, `FULL`, or `NONE`. |
+
+The summary interpolates `${result.compatibility}`, such as `Compatibility level set to FULL`.

--- a/src/reference/config/bindings/mcp-schema-registry/.partials/tools.md
+++ b/src/reference/config/bindings/mcp-schema-registry/.partials/tools.md
@@ -2,6 +2,8 @@ The `mcp-schema-registry` client exposes a fixed set of intrinsic tools, derived
 
 ### list_subjects
 
+> Read-only, idempotent
+
 Lists every subject registered in the schema registry.
 
 No arguments.
@@ -9,6 +11,8 @@ No arguments.
 The result's `structuredContent` mirrors the raw upstream JSON response — an array of subject names.
 
 ### describe_subject
+
+> Read-only, idempotent
 
 Lists the schema version numbers registered for a subject.
 
@@ -19,6 +23,8 @@ Lists the schema version numbers registered for a subject.
 The result's `structuredContent` mirrors the raw upstream JSON response — an array of version numbers.
 
 ### register_schema
+
+> Not destructive, not idempotent
 
 Registers a new schema version under a subject.
 
@@ -32,6 +38,8 @@ The summary interpolates `${result.id}`, such as `Registered schema with id 1`.
 
 ### get_schema
 
+> Read-only, idempotent
+
 Retrieves a specific registered schema version for a subject.
 
 | Argument | Type | Required | Description |
@@ -43,6 +51,8 @@ The summary interpolates `${result.id}` and `${result.version}`, such as `Retrie
 
 ### delete_schema_version
 
+> Destructive, idempotent
+
 Deletes a specific registered schema version for a subject.
 
 | Argument | Type | Required | Description |
@@ -51,6 +61,8 @@ Deletes a specific registered schema version for a subject.
 | `version` | `string` | Yes | Schema version number, or `latest`. |
 
 ### delete_subject
+
+> Destructive, idempotent
 
 Deletes a subject and every schema version registered under it.
 
@@ -61,6 +73,8 @@ Deletes a subject and every schema version registered under it.
 The result's `structuredContent` mirrors the raw upstream JSON response — an array of the deleted subject's version numbers.
 
 ### check_compatibility
+
+> Read-only, idempotent
 
 Checks whether a schema is compatible with a specific already-registered version of a subject.
 
@@ -75,6 +89,8 @@ The summary interpolates `${result.is_compatible}`, such as `Compatibility check
 
 ### get_compatibility
 
+> Read-only, idempotent
+
 Reads the compatibility level configured for a subject.
 
 | Argument | Type | Required | Description |
@@ -84,6 +100,8 @@ Reads the compatibility level configured for a subject.
 The summary interpolates `${result.compatibilityLevel}`, such as `Compatibility level is FULL`.
 
 ### set_compatibility
+
+> Not destructive, idempotent
 
 Sets the compatibility level for a subject.
 

--- a/src/reference/config/bindings/mcp-schema-registry/.partials/tools.md
+++ b/src/reference/config/bindings/mcp-schema-registry/.partials/tools.md
@@ -1,0 +1,79 @@
+The `mcp-schema-registry` client exposes a fixed set of intrinsic tools, derived from a bundled schema registry API specification — there is no `options.tools` to author, and no upstream server or spec to select. Each tool's `inputSchema` validates `tools/call` `arguments` before Zilla dispatches the matching request to `options.server`. None of these tools declare a fixed `outputSchema`; each returns a `content` text summary, though the summary may interpolate fields of the raw upstream JSON response, such as `${result.id}`.
+
+### list_subjects
+
+Lists every subject registered in the schema registry.
+
+No arguments.
+
+### describe_subject
+
+Lists the schema version numbers registered for a subject.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `subject` | `string` | Yes | Subject to list versions for. |
+
+### register_schema
+
+Registers a new schema version under a subject.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `subject` | `string` | Yes | Subject to register the schema under. |
+| `schema` | `string` | Yes | Schema document to register. |
+| `schemaType` | `string` | No | Schema format, such as `AVRO`, `JSON`, or `PROTOBUF`. Defaults to `AVRO` when omitted. |
+
+### get_schema
+
+Retrieves a specific registered schema version for a subject.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `subject` | `string` | Yes | Subject to read from. |
+| `version` | `string` | Yes | Schema version number, or `latest`. |
+
+### delete_schema_version
+
+Deletes a specific registered schema version for a subject.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `subject` | `string` | Yes | Subject to delete from. |
+| `version` | `string` | Yes | Schema version number, or `latest`. |
+
+### delete_subject
+
+Deletes a subject and every schema version registered under it.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `subject` | `string` | Yes | Subject to delete. |
+
+### check_compatibility
+
+Checks whether a schema is compatible with a specific already-registered version of a subject.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `subject` | `string` | Yes | Subject to check compatibility against. |
+| `version` | `string` | Yes | Schema version number, or `latest`, to check compatibility against. |
+| `schema` | `string` | Yes | Schema document to check. |
+| `schemaType` | `string` | No | Schema format, such as `AVRO`, `JSON`, or `PROTOBUF`. Defaults to `AVRO` when omitted. |
+
+### get_compatibility
+
+Reads the compatibility level configured for a subject.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `subject` | `string` | Yes | Subject to read the compatibility level of. |
+
+### set_compatibility
+
+Sets the compatibility level for a subject.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `subject` | `string` | Yes | Subject to set the compatibility level of. |
+| `compatibility` | `string` | Yes | Compatibility level, such as `BACKWARD`, `FORWARD`, `FULL`, or `NONE`. |

--- a/src/reference/config/bindings/mcp-schema-registry/README.md
+++ b/src/reference/config/bindings/mcp-schema-registry/README.md
@@ -1,0 +1,22 @@
+---
+shortTitle: mcp-schema-registry
+category:
+  - Binding
+tag:
+  - mcp-schema-registry
+  - client
+---
+
+# mcp-schema-registry Binding
+
+The `client` kind `mcp-schema-registry` binding exposes a Karapace-compatible schema registry's subject, schema, and compatibility operations as a fixed set of intrinsic MCP tools, connecting directly to the registry named by `options.server`, with no upstream MCP server, OpenAPI spec, or per-tool schema authoring.
+
+## client
+
+> [Full config](./client.md)
+
+Behave as an `mcp-schema-registry` `client`.
+
+```yaml {3}
+<!-- @include: ./.partials/client.yaml -->
+```

--- a/src/reference/config/bindings/mcp-schema-registry/client.md
+++ b/src/reference/config/bindings/mcp-schema-registry/client.md
@@ -1,0 +1,21 @@
+---
+shortTitle: client
+---
+
+# mcp-schema-registry client
+
+The `mcp-schema-registry` client binding exposes a Karapace-compatible schema registry's subject, schema, and compatibility operations as a fixed set of intrinsic MCP tools, connecting directly to the registry named by `options.server` — unlike [`mcp-openapi`](../mcp-openapi/client.md), there is no upstream spec or per-tool schema to author. [`mcp-kafka`](../mcp-kafka/client.md) and [`mcp-kafka-connect`](../mcp-kafka-connect/client.md) follow the same fixed-tool pattern for the Kafka broker and Kafka Connect REST APIs.
+
+```yaml {3}
+<!-- @include: ./.partials/client.yaml -->
+```
+
+## Configuration (\* required)
+
+<!-- @include: ./.partials/options.md -->
+<!-- @include: ./.partials/routes.md -->
+<!-- @include: ../.partials/telemetry.md -->
+
+## Tools
+
+<!-- @include: ./.partials/tools.md -->


### PR DESCRIPTION
## Summary

- `mcp-kafka-connect` and `mcp-schema-registry` are two `mcp*` bindings added to zilla's `develop` branch that had no reference documentation yet — `support/2.x` already documents `mcp`, `mcp-http`, `mcp-kafka`, and `mcp-openapi` (#413–#416), but these two were missing.
- Both bindings follow the same `client`-only composite pattern already established for `mcp-kafka`/`mcp-openapi`: a fixed set of intrinsic MCP tools generated from a bundled OpenAPI spec (the Kafka Connect REST API, and a Karapace-compatible schema registry API respectively), routed by `tool` name/glob with optional `guarded` roles — no `options.tools`/`options.resources` authoring, no `with`.
- Adds `src/reference/config/bindings/mcp-kafka-connect/` and `src/reference/config/bindings/mcp-schema-registry/` (`README.md`, `client.md`, and `.partials/{client.yaml,options.md,routes.md,tools.md}` each), each `tools.md` enumerating every intrinsic tool (18 for Kafka Connect, 9 for schema registry) with its arguments and output behavior, derived directly from the bindings' bundled OpenAPI documents.
- Wires both into `src/.vuepress/sidebar/en.ts` (`children: "structure"`, matching the existing MCP-* entries).
- Cross-links the sibling `mcp-kafka`/`mcp-kafka-connect`/`mcp-schema-registry`/`mcp-openapi` client pages to each other in their intro paragraphs.

## Test plan

- [x] `pnpm lint` — no new violations introduced by this change (all reported issues are pre-existing, in unrelated files)
- [x] `pnpm check-schema` — produces no output referencing either new binding (the tracked `.check-schema/zilla-schema.json` predates these bindings and doesn't define their types yet, consistent with the pre-existing `mcp-http` gap in that file — these bindings are still unreleased on zilla's `develop` branch)
- [ ] Visual check of the rendered sidebar/pages via `pnpm dev` (not run in this environment)


---
_Generated by [Claude Code](https://claude.ai/code/session_014ikToCpeJTceYRhdyZNGRw)_